### PR TITLE
Manage multi threading manually

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 
 [workspace]
+resolver = "2"
 
 members = [
     "lantern_extras",

--- a/lantern_create_index/Cargo.toml
+++ b/lantern_create_index/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/main.rs"
 anyhow = "1.0.75"
 clap = { version = "4.4.0", features = ["derive"] }
 cxx = "1.0.106"
+postgres = "0.19.7"
 postgres-types = { version = "0.2.6", features = ["derive"] }
-tokio = { version = "1.32.0", features = ["full" ] }
-tokio-postgres = "0.7.10"
+threadpool = "1.8.1"
 usearch = { git = "https://github.com/Ngalstyan4/usearch.git", branch = "pg-rebase" }

--- a/lantern_create_index/Cargo.toml
+++ b/lantern_create_index/Cargo.toml
@@ -19,5 +19,4 @@ clap = { version = "4.4.0", features = ["derive"] }
 cxx = "1.0.106"
 postgres = "0.19.7"
 postgres-types = { version = "0.2.6", features = ["derive"] }
-threadpool = "1.8.1"
 usearch = { git = "https://github.com/Ngalstyan4/usearch.git", branch = "pg-rebase" }


### PR DESCRIPTION
## Description
Used the function `add_in_thread` exposed from usearch which will use the context allocated for the n-th thread under the hood. If `USEARCH_CONCURRENT` is enabled on build time it automatically creates contexts with the count of CPUs.

We will spawn threads according the count of CPUs then the threads will poll the data from a channel which is like a queue.
From main thread we will query the database via portal transaction in 2000 chunks and send the data to worker threads.
Then the treads will get the data and add it to index.

The execution time in Macbook Pro (i7 12 threads) improved from 14s to 3s for 100k rows.
For 1m rows it takes around 38-40s to index them.