### PR TITLE
Add external index functions to SQL and make index creation in one transaction with lock

### DIFF
--- a/lantern_cli/Cargo.toml
+++ b/lantern_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lantern_cli"
-version = "0.0.18"
+version = "0.0.19"
 edition = "2021"
 
 [[bin]]

--- a/lantern_create_index/Cargo.toml
+++ b/lantern_create_index/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lantern_create_index"
-version = "0.0.1"
+version = "0.0.2"
 edition = "2021"
 
 [lib]

--- a/lantern_create_index/src/cli.rs
+++ b/lantern_create_index/src/cli.rs
@@ -113,7 +113,7 @@ pub struct CreateIndexArgs {
     pub ef: usize,
 
     /// Dimensions of vector
-    #[arg(short)]
+    #[arg(short, default_value_t = 0)]
     pub dims: usize,
 
     /// Distance algorithm

--- a/lantern_create_index/src/cli.rs
+++ b/lantern_create_index/src/cli.rs
@@ -9,6 +9,20 @@ pub enum UMetricKind {
 }
 
 impl UMetricKind {
+    pub fn from_ops(ops: &str) -> Result<UMetricKind, anyhow::Error> {
+        match ops {
+            "dist_l2sq_ops" => {
+                return Ok(UMetricKind::L2sq);
+            }
+            "dist_cos_ops" => {
+                return Ok(UMetricKind::Cos);
+            }
+            "dist_hamming_ops" => {
+                return Ok(UMetricKind::Hamming);
+            }
+            _ => anyhow::bail!("Invalid ops {ops}"),
+        }
+    }
     pub fn from(metric_kind: &str) -> Result<UMetricKind, anyhow::Error> {
         match metric_kind {
             "l2sq" => {
@@ -24,6 +38,19 @@ impl UMetricKind {
                 return Ok(UMetricKind::Hamming);
             }
             _ => anyhow::bail!("Invalid metric {metric_kind}"),
+        }
+    }
+    pub fn to_string(&self) -> String {
+        match self {
+            UMetricKind::L2sq => {
+                return "l2sq".to_owned();
+            }
+            UMetricKind::Cos => {
+                return "cos".to_owned();
+            }
+            UMetricKind::Hamming => {
+                return "hamming".to_owned();
+            }
         }
     }
     pub fn value(&self) -> MetricKind {

--- a/lantern_create_index/src/lib.rs
+++ b/lantern_create_index/src/lib.rs
@@ -102,35 +102,48 @@ pub fn create_usearch_index(
     client: Option<Client>,
 ) -> Result<(), anyhow::Error> {
     let logger = Arc::new(logger.unwrap_or(Logger::new("Lantern Index", LogLevel::Debug)));
-    logger.info(&format!(
-        "Creating index with parameters dimensions={} m={} ef={} ef_construction={}",
-        args.dims, args.m, args.ef, args.efc
-    ));
-
-    let options = IndexOptions {
-        dimensions: args.dims,
-        metric: args.metric_kind.value(),
-        quantization: ScalarKind::F32,
-        connectivity: args.m,
-        expansion_add: args.efc,
-        expansion_search: args.ef,
-    };
-
     let num_cores: usize = std::thread::available_parallelism().unwrap().into();
     logger.info(&format!("Number of available CPU cores: {}", num_cores));
 
-    let index = new_index(&options)?;
     // get all row count
     let mut client = client.unwrap_or(Client::connect(&args.uri, NoTls)?);
     let mut transaction = client.transaction()?;
     let full_table_name = get_full_table_name(&args.schema, &args.table);
 
     transaction.execute(
-        &format!("LOCK TABLE ONLY {full_table_name} IN ACCESS EXCLUSIVE MODE"),
+        &format!("LOCK TABLE ONLY {full_table_name} IN ACCESS EXCLUSIVE MODE NOWAIT"),
         &[],
     )?;
 
     let rows = transaction.query(&format!("SELECT COUNT(*) FROM {full_table_name};",), &[])?;
+
+    let row = transaction.query_one(&format!("SELECT ARRAY_LENGTH({col}, 1) as dim FROM {full_table_name} WHERE {col} IS NOT NULL LIMIT 1",col=quote_ident(&args.column)), &[])?;
+
+    let infered_dimensions = row.try_get::<usize, i32>(0)? as usize;
+
+    if args.dims != 0 && infered_dimensions != args.dims {
+        // I didn't complitely remove the dimensions from args
+        // To have extra validation when reindexing external index
+        // This is invariant and should never be a case
+        anyhow::bail!("Infered dimensions ({infered_dimensions}) does not match with the provided dimensions ({dims})", dims=args.dims);
+    }
+
+    let dimensions = infered_dimensions;
+
+    logger.info(&format!(
+        "Creating index with parameters dimensions={} m={} ef={} ef_construction={}",
+        dimensions, args.m, args.ef, args.efc
+    ));
+
+    let options = IndexOptions {
+        dimensions,
+        metric: args.metric_kind.value(),
+        quantization: ScalarKind::F32,
+        connectivity: args.m,
+        expansion_add: args.efc,
+        expansion_search: args.ef,
+    };
+    let index = new_index(&options)?;
 
     let count: i64 = rows[0].get(0);
     // reserve enough memory on index
@@ -226,7 +239,7 @@ pub fn create_usearch_index(
             args.index_name.as_deref(),
             args.ef,
             args.efc,
-            args.dims,
+            dimensions,
             args.m,
         )?;
         logger.info(&format!(

--- a/lantern_extras/Cargo.toml
+++ b/lantern_extras/Cargo.toml
@@ -26,7 +26,6 @@ url = "2.2"
 lantern_embeddings_core = { path = "../lantern_embeddings_core" }
 lantern_create_index = { path = "../lantern_create_index" }
 anyhow = "1.0.75"
-regex = "1.10.2"
 
 [dev-dependencies]
 pgrx-tests = "=0.9.7"

--- a/lantern_extras/Cargo.toml
+++ b/lantern_extras/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lantern_extras"
-version = "0.0.4"
+version = "0.0.5"
 edition = "2021"
 
 [lib]
@@ -24,6 +24,9 @@ itertools = "0.11"
 backtrace = "0.3"
 url = "2.2"
 lantern_embeddings_core = { path = "../lantern_embeddings_core" }
+lantern_create_index = { path = "../lantern_create_index" }
+anyhow = "1.0.75"
+regex = "1.10.2"
 
 [dev-dependencies]
 pgrx-tests = "=0.9.7"

--- a/lantern_extras/src/lib.rs
+++ b/lantern_extras/src/lib.rs
@@ -2,6 +2,8 @@ use pgrx::prelude::*;
 
 use flate2::read::GzDecoder;
 use ftp::FtpStream;
+use lantern_create_index::cli::CreateIndexArgs;
+use lantern_create_index::cli::UMetricKind;
 use lantern_embeddings_core;
 use tar::Archive;
 
@@ -10,6 +12,126 @@ pub mod dotvecs;
 
 fn notice_fn(text: &str) {
     notice!("{}", text);
+}
+
+#[pg_extern(immutable, parallel_unsafe)]
+fn lantern_create_external_index<'a>(
+    column: &'a str,
+    table: &'a str,
+    schema: default!(&'a str, "'public'"),
+    metric_kind: default!(&'a str, "'l2sq'"),
+    dim: default!(i32, 0),
+    m: default!(i32, 16),
+    ef_construction: default!(i32, 16),
+    ef: default!(i32, 16),
+    index_name: default!(&'a str, "''"),
+) -> Result<(), anyhow::Error> {
+    let (db, user, socket_path, port) = Spi::connect(|client| {
+        let row = client
+            .select(
+                "
+           SELECT current_database()::text AS db,
+           current_user::text AS user,
+           (SELECT setting::text FROM pg_settings WHERE name = 'unix_socket_directories') AS socket_path,
+           (SELECT setting::text FROM pg_settings WHERE name = 'port') AS port",
+                None,
+                None,
+            )?
+            .first();
+
+        let db = row.get_by_name::<String, &str>("db")?.unwrap();
+        let user = row.get_by_name::<String, &str>("user")?.unwrap();
+        let socket_path = row.get_by_name::<String, &str>("socket_path")?.unwrap();
+        let port = row.get_by_name::<String, &str>("port")?.unwrap();
+        Ok::<(String, String, String, String), anyhow::Error>((db, user, socket_path, port))
+    })?;
+
+    let connection_string = format!("dbname={db} host={socket_path} user={user} port={port}");
+
+    let index_name = if index_name == "" {
+        None
+    } else {
+        Some(index_name.to_owned())
+    };
+
+    let res = lantern_create_index::create_usearch_index(
+        &CreateIndexArgs {
+            import: true,
+            out: "/tmp/index.usearch".to_owned(),
+            table: table.to_owned(),
+            schema: schema.to_owned(),
+            metric_kind: UMetricKind::from(metric_kind)?,
+            efc: ef_construction as usize,
+            ef: ef as usize,
+            m: m as usize,
+            uri: connection_string,
+            column: column.to_owned(),
+            dims: dim as usize,
+            index_name,
+        },
+        None,
+        None,
+    );
+
+    if let Err(e) = res {
+        error!("{e}");
+    }
+
+    Ok(())
+}
+
+#[pg_extern(immutable, parallel_unsafe)]
+fn _lantern_reindex_external_index<'a>(
+    index_name: &'a str,
+    metric_kind: &'a str,
+    dim: i32,
+    m: i32,
+    ef_construction: i32,
+    ef: i32,
+) -> Result<(), anyhow::Error> {
+    let (schema, table, column) = Spi::connect(|client| {
+        let rows = client.select(
+            "
+                SELECT idxs.schemaname::text          AS schema_name,
+                       idx.indrelid::regclass::text   AS table_name,
+                       att.attname::text              AS column_name
+                FROM   pg_index AS idx
+                       JOIN pg_attribute AS att
+                         ON att.attrelid = idx.indrelid
+                            AND att.attnum = ANY(idx.indkey)
+                       INNER JOIN pg_indexes AS idxs
+                               ON idxs.indexname = $1
+                WHERE  idx.indexrelid = idxs.indexname::regclass",
+            None,
+            Some(vec![(
+                PgBuiltInOids::TEXTOID.oid(),
+                index_name.into_datum(),
+            )]),
+        )?;
+
+        if rows.len() == 0 {
+            error!("Index {index_name} not found");
+        }
+
+        let row = rows.first();
+
+        let schema = row.get_by_name::<String, &str>("schema_name")?.unwrap();
+        let table = row.get_by_name::<String, &str>("table_name")?.unwrap();
+        let column = row.get_by_name::<String, &str>("column_name")?.unwrap();
+        Ok::<(String, String, String), anyhow::Error>((schema, table, column))
+    })?;
+
+    lantern_create_external_index(
+        &column,
+        &table,
+        &schema,
+        metric_kind,
+        dim,
+        m,
+        ef_construction,
+        ef,
+        index_name,
+    )
 }
 
 #[pg_extern(immutable, parallel_safe)]

--- a/lantern_extras/src/lib.rs
+++ b/lantern_extras/src/lib.rs
@@ -14,6 +14,12 @@ fn notice_fn(text: &str) {
     notice!("{}", text);
 }
 
+fn validate_index_param(param_name: &str, param_val: i32, min: i32, max: i32) {
+    if param_val < min || param_val > max {
+        error!("{param_name} should be in range [{min}, {max}]");
+    }
+}
+
 #[pg_extern(immutable, parallel_unsafe)]
 fn lantern_create_external_index<'a>(
     column: &'a str,
@@ -26,6 +32,15 @@ fn lantern_create_external_index<'a>(
     ef: default!(i32, 16),
     index_name: default!(&'a str, "''"),
 ) -> Result<(), anyhow::Error> {
+    validate_index_param("ef", ef, 1, 400);
+    validate_index_param("ef_construction", ef_construction, 1, 400);
+    validate_index_param("ef_construction", ef_construction, 1, 400);
+    validate_index_param("m", m, 2, 128);
+
+    if dim != 0 {
+        validate_index_param("dim", dim, 1, 2000);
+    }
+
     let (db, user, socket_path, port) = Spi::connect(|client| {
         let row = client
             .select(
@@ -43,6 +58,7 @@ fn lantern_create_external_index<'a>(
         let user = row.get_by_name::<String, &str>("user")?.unwrap();
         let socket_path = row.get_by_name::<String, &str>("socket_path")?.unwrap();
         let port = row.get_by_name::<String, &str>("port")?.unwrap();
+
         Ok::<(String, String, String, String), anyhow::Error>((db, user, socket_path, port))
     })?;
 


### PR DESCRIPTION
Added two sql functions `lantern_create_external_index` and `_lantern_reindex_external_index`

The first one is used to create an external index right from SQL, this will call the `lantern_create_index` crate under the hood and import the index. If `index_name` is specified, it will try to drop the existing index before creating a new one.

Second function is prefixed with underscore as it is not intended to be called directly, but instead it will be called from lantern extension's `lantern_reindex_external_index` function, which will provide necessary index params from index header block.

There are some changes done in `lantern_create_index` crate as well, it will now run all the operations in one transaction exclusively locking the table, so now more mismatched data will be in the index if `--import` is passed.

It will also infer and validate the index dimensions which will cover an issue #19 