### PR TITLE
Fix external index metric and add retry policy to HTTP runtime

### DIFF
--- a/.github/workflows/publish-cli-docker.yaml
+++ b/.github/workflows/publish-cli-docker.yaml
@@ -6,7 +6,7 @@ on:
         type: string
         description: "CLI version"
         required: true
-        default: "0.0.34"
+        default: "0.0.35"
       IMAGE_NAME:
         type: string
         description: "Container image name to tag"

--- a/lantern_cli/Cargo.toml
+++ b/lantern_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lantern_cli"
-version = "0.0.34"
+version = "0.0.35"
 edition = "2021"
 
 [[bin]]

--- a/lantern_embeddings_core/src/http_runtime.rs
+++ b/lantern_embeddings_core/src/http_runtime.rs
@@ -19,6 +19,7 @@ macro_rules! HTTPRuntime {
         use std::sync::Arc;
         use tokio::runtime::Runtime;
         use url::Url;
+        use crate::utils::post_with_retries;
 
         impl<'a> IHTTPRuntime for $a<'a> {
             fn get_client(&self) -> Result<HttpClient, anyhow::Error> {
@@ -48,7 +49,7 @@ macro_rules! HTTPRuntime {
                     let client = client.clone();
                     let url = url.clone();
                     let task = tokio_runtime
-                        .spawn(async move { client.post_async(url, request_body).await });
+                        .spawn(async move { post_with_retries(client, url, request_body, 3).await });
                     tasks.push(task);
                 }
 

--- a/lantern_external_index/src/cli.rs
+++ b/lantern_external_index/src/cli.rs
@@ -23,6 +23,19 @@ impl UMetricKind {
             _ => anyhow::bail!("Invalid ops {ops}"),
         }
     }
+    pub fn to_ops(&self) -> String {
+        match self {
+            UMetricKind::L2sq => {
+                return "dist_l2sq_ops".to_owned();
+            }
+            UMetricKind::Cos => {
+                return "dist_cos_ops".to_owned();
+            }
+            UMetricKind::Hamming => {
+                return "dist_hamming_ops".to_owned();
+            }
+        }
+    }
     pub fn from(metric_kind: &str) -> Result<UMetricKind, anyhow::Error> {
         match metric_kind {
             "l2sq" => {

--- a/lantern_external_index/src/lib.rs
+++ b/lantern_external_index/src/lib.rs
@@ -295,6 +295,7 @@ pub fn create_usearch_index(
     drop(rx_arc);
 
     if args.import {
+        let op_class = args.metric_kind.to_ops();
         if args.remote_database {
             logger.info("Copying index file into database server...");
             let mut rng = rand::thread_rng();
@@ -316,6 +317,7 @@ pub fn create_usearch_index(
                 &get_full_table_name(&args.schema, &args.table),
                 &quote_ident(&args.column),
                 args.index_name.as_deref(),
+                &op_class,
                 args.ef,
                 args.efc,
                 dimensions,
@@ -334,7 +336,7 @@ pub fn create_usearch_index(
             }
 
             transaction.execute(
-            &format!("CREATE INDEX {idx_name} ON {table_name} USING hnsw({column_name}) WITH (_experimental_index_path='{index_path}', ef={ef}, dim={dim}, m={m}, ef_construction={ef_construction});", index_path=args.out, table_name=&get_full_table_name(&args.schema, &args.table),column_name=&quote_ident(&args.column), m=args.m, ef=args.ef, ef_construction=args.efc, dim=dimensions),
+            &format!("CREATE INDEX {idx_name} ON {table_name} USING hnsw({column_name} {op_class}) WITH (_experimental_index_path='{index_path}', ef={ef}, dim={dim}, m={m}, ef_construction={ef_construction});", index_path=args.out, table_name=&get_full_table_name(&args.schema, &args.table),column_name=&quote_ident(&args.column), m=args.m, ef=args.ef, ef_construction=args.efc, dim=dimensions),
             &[],
             )?;
 

--- a/lantern_external_index/src/postgres_large_objects.rs
+++ b/lantern_external_index/src/postgres_large_objects.rs
@@ -36,6 +36,7 @@ impl<'a> LargeObject<'a> {
         table_name: &str,
         column_name: &str,
         index_name: Option<&str>,
+        op_class: &str,
         ef: usize,
         ef_construction: usize,
         dim: usize,
@@ -56,7 +57,7 @@ impl<'a> LargeObject<'a> {
         }
 
         transaction.execute(
-            &format!("CREATE INDEX {idx_name} ON {table_name} USING hnsw({column_name}) WITH (_experimental_index_path='{index_path}', ef={ef}, dim={dim}, m={m}, ef_construction={ef_construction});", index_path=self.index_path),
+            &format!("CREATE INDEX {idx_name} ON {table_name} USING hnsw({column_name} {op_class}) WITH (_experimental_index_path='{index_path}', ef={ef}, dim={dim}, m={m}, ef_construction={ef_construction});", index_path=self.index_path),
             &[],
         )?;
 

--- a/lantern_extras/Cargo.toml
+++ b/lantern_extras/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lantern_extras"
-version = "0.0.11"
+version = "0.0.12"
 edition = "2021"
 
 [lib]

--- a/lantern_extras/Cargo.toml
+++ b/lantern_extras/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lantern_extras"
-version = "0.0.12"
+version = "0.0.13"
 edition = "2021"
 
 [lib]

--- a/lantern_extras/Cargo.toml
+++ b/lantern_extras/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lantern_extras"
-version = "0.0.13"
+version = "0.0.12"
 edition = "2021"
 
 [lib]


### PR DESCRIPTION
- When we were creating an external index we were not passing the operator class, letting the index to read it from file. This was okay for index creation, but when doing queries for example with `<=>` (cosine) operator the postgres was not detecting an index scan as `<=>` operator is connected with `dist_cos_ops` operator class and if we don't specify the operator class it will fallback to `l2sq_dist_ops` by default.

- Added retry mechanism to HTTP runtime, so in case if there will be errors from Cohere or OpenAI APIs we will retry 3 times before throwing