### PR TITLE
Fix daemon deadlock

### DIFF
--- a/.github/workflows/publish-cli-docker.yaml
+++ b/.github/workflows/publish-cli-docker.yaml
@@ -11,7 +11,7 @@ on:
         type: string
         description: "CLI version"
         required: true
-        default: "0.1.6"
+        default: "0.1.7"
       IMAGE_NAME:
         type: string
         description: "Container image name to tag"

--- a/.github/workflows/publish-cli-docker.yaml
+++ b/.github/workflows/publish-cli-docker.yaml
@@ -68,9 +68,6 @@ jobs:
           push: true
           # the :latest tag will refer to cpu version
           tags: |
-            ${{ (matrix.device == 'cpu' && format('{0}:latest', inputs.IMAGE_NAME) || format('{0}:gpu', inputs.IMAGE_NAME)) }}
-            ${{ inputs.IMAGE_NAME }}:latest-${{ matrix.device }}
-            ${{ inputs.IMAGE_NAME }}:${{ inputs.VERSION }}-${{ matrix.device }}
             ${{ (matrix.device == 'cpu' && format('{0}-docker.pkg.dev/{1}/{2}:latest', secrets.GCP_REGION, secrets.GCP_PROJECT_ID, inputs.IMAGE_NAME) || format('{0}-docker.pkg.dev/{1}/{2}:gpu', secrets.GCP_REGION, secrets.GCP_PROJECT_ID, inputs.IMAGE_NAME)) }}
             ${{ secrets.GCP_REGION }}-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/${{ inputs.IMAGE_NAME }}:latest-${{ matrix.device }}
             ${{ secrets.GCP_REGION }}-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/${{ inputs.IMAGE_NAME }}:${{ inputs.VERSION }}-${{ matrix.device }}

--- a/Dockerfile.cli
+++ b/Dockerfile.cli
@@ -9,7 +9,7 @@ RUN rm -rf lantern_extras && sed -i -e 's/"lantern_extras",//' Cargo.toml
 # Build your program for release
 RUN apt update && \
   apt install -y --no-install-recommends wget build-essential pkg-config clang curl libssl-dev && \
-  cargo build --release --package lantern_cli
+  RUSTFLAGS="--cfg tokio_unstable" cargo build --release --package lantern_cli
 
 FROM debian:12
 COPY --from=build /app/target/release/lantern-cli .

--- a/Dockerfile.cli.cuda
+++ b/Dockerfile.cli.cuda
@@ -9,7 +9,7 @@ RUN rm -rf lantern_extras && sed -i -e 's/"lantern_extras",//' Cargo.toml
 # Build your program for release
 RUN apt update && \
   apt install -y --no-install-recommends wget build-essential pkg-config clang curl libssl-dev && \
-  cargo build --release --package lantern_cli
+  RUSTFLAGS="--cfg tokio_unstable" cargo build --release --package lantern_cli
 
 FROM nvcr.io/nvidia/cuda:12.3.1-runtime-ubuntu22.04
 COPY --from=build /app/target/release/lantern-cli .

--- a/Dockerfile.cli.cuda
+++ b/Dockerfile.cli.cuda
@@ -9,12 +9,18 @@ RUN rm -rf lantern_extras && sed -i -e 's/"lantern_extras",//' Cargo.toml
 # Build your program for release
 RUN apt update && \
   apt install -y --no-install-recommends wget build-essential pkg-config clang curl libssl-dev && \
-  RUSTFLAGS="--cfg tokio_unstable" cargo build --release --package lantern_cli
+  RUSTFLAGS="--cfg tokio_unstable" cargo build --package lantern_cli
 
 FROM nvcr.io/nvidia/cuda:12.3.1-runtime-ubuntu22.04
-COPY --from=build /app/target/release/lantern-cli .
+COPY --from=build /app/target/debug/lantern-cli .
 RUN apt update && \
-  apt install -y wget && apt clean
+  apt install -y wget build-essential curl && apt clean
+
+RUN curl -k -o /tmp/rustup.sh https://sh.rustup.rs && \
+    chmod +x /tmp/rustup.sh && \
+    /tmp/rustup.sh -y && \
+    . "$HOME/.cargo/env" && \
+    cargo install --locked tokio-console
 # Download onnxruntime
 RUN mkdir -p /usr/local/lib && \
     cd /usr/local/lib && \

--- a/lantern_cli/Cargo.toml
+++ b/lantern_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lantern_cli"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 
 [[bin]]

--- a/lantern_cli/Cargo.toml
+++ b/lantern_cli/Cargo.toml
@@ -25,7 +25,7 @@ serde_json = "1.0.111"
 gcp_auth = {version="0.10.0", optional=true}
 tokio-postgres = { version="0.7.10", optional=true }
 futures = "0.3.28"
-tokio = { version = "1.33.0", features = ["full"] }
+tokio = { version = "1.33.0", features = ["full", "tracing"] }
 lazy_static = "1.4.0"
 itertools = "0.11.0"
 csv = "1.3.0"
@@ -48,6 +48,7 @@ deadpool = {version="0.10.0", optional=true}
 bytes = {version="1.5.0", optional=true}
 utoipa = {version="4.2.0", optional=true}
 utoipa-swagger-ui = { version= "6.0.0", features=["actix-web"], optional=true }
+console-subscriber = "0.2.0"
 
 [features]
 default = ["cli", "daemon", "http-server", "autotune", "pq", "external-index", "embeddings"]

--- a/lantern_cli/Cargo.toml
+++ b/lantern_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lantern_cli"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 
 [[bin]]

--- a/lantern_cli/src/daemon/client_embedding_jobs.rs
+++ b/lantern_cli/src/daemon/client_embedding_jobs.rs
@@ -28,6 +28,7 @@ pub async fn toggle_client_job(
     job_id: i32,
     db_uri: String,
     column: String,
+    out_column: String,
     table: String,
     schema: String,
     log_level: LogLevel,
@@ -45,6 +46,7 @@ pub async fn toggle_client_job(
                 job_id,
                 db_uri,
                 column,
+                out_column,
                 table,
                 schema,
                 job_insert_queue_tx,
@@ -245,6 +247,7 @@ async fn start_client_job(
     job_id: i32,
     db_uri: String,
     column: String,
+    out_column: String,
     table: String,
     schema: String,
     job_insert_queue_tx: Sender<JobInsertNotification>,
@@ -344,7 +347,11 @@ async fn start_client_job(
                                 init: false,
                                 generate_missing: true,
                                 row_id: None,
-                                filter: None,
+                                filter: Some(format!(
+                                    "({src_column} IS NOT NULL OR {src_column} != '') AND {out_column} IS NULL",
+                                    src_column=quote_ident(&column),
+                                    out_column=quote_ident(&out_column),
+                                )),
                                 limit: None,
                             })
                             .await?;

--- a/lantern_cli/src/daemon/client_embedding_jobs.rs
+++ b/lantern_cli/src/daemon/client_embedding_jobs.rs
@@ -338,6 +338,16 @@ async fn start_client_job(
 
                     if let Ok(tx) = res {
                         cancel_listener_task = tx;
+                        job_insert_queue_tx
+                            .send(JobInsertNotification {
+                                id: job_id,
+                                init: false,
+                                generate_missing: true,
+                                row_id: None,
+                                filter: None,
+                                limit: None,
+                            })
+                            .await?;
                         break;
                     } else {
                         tokio::time::sleep(Duration::from_secs(10)).await;

--- a/lantern_cli/src/daemon/client_embedding_jobs.rs
+++ b/lantern_cli/src/daemon/client_embedding_jobs.rs
@@ -194,6 +194,7 @@ async fn client_notification_listener(
                 let _ = job_signal_tx.send(Signal::Restart).await;
                 break;
             }
+            logger.debug("Received message");
 
             let message = message.unwrap();
 

--- a/lantern_cli/src/daemon/embedding_jobs.rs
+++ b/lantern_cli/src/daemon/embedding_jobs.rs
@@ -557,8 +557,8 @@ async fn create_data_path(logger: Arc<Logger>) -> &'static str {
 
 #[tokio::main]
 pub async fn start(args: cli::DaemonArgs, logger: Arc<Logger>) -> AnyhowVoidResult {
-    logger.info("Starting Embedding Jobs");
     console_subscriber::init();
+    logger.info("Starting Embedding Jobs");
 
     let (main_db_client, connection) = tokio_postgres::connect(&args.uri, NoTls).await?;
     tokio::spawn(async move { connection.await.unwrap() });

--- a/lantern_cli/src/daemon/embedding_jobs.rs
+++ b/lantern_cli/src/daemon/embedding_jobs.rs
@@ -558,6 +558,7 @@ async fn create_data_path(logger: Arc<Logger>) -> &'static str {
 #[tokio::main]
 pub async fn start(args: cli::DaemonArgs, logger: Arc<Logger>) -> AnyhowVoidResult {
     logger.info("Starting Embedding Jobs");
+    console_subscriber::init();
 
     let (main_db_client, connection) = tokio_postgres::connect(&args.uri, NoTls).await?;
     tokio::spawn(async move { connection.await.unwrap() });

--- a/lantern_cli/src/daemon/helpers.rs
+++ b/lantern_cli/src/daemon/helpers.rs
@@ -1,8 +1,8 @@
 use super::types::JobTaskCancelTx;
 use super::types::{JobCancellationHandlersMap, JobInsertNotification, JobUpdateNotification};
 use crate::logger::Logger;
-use crate::utils::{get_full_table_name, quote_ident};
 use crate::types::AnyhowVoidResult;
+use crate::utils::{get_full_table_name, quote_ident};
 use futures::StreamExt;
 use std::sync::Arc;
 use std::time::SystemTime;

--- a/lantern_cli/src/daemon/types.rs
+++ b/lantern_cli/src/daemon/types.rs
@@ -24,7 +24,7 @@ pub struct EmbeddingJob {
 }
 
 impl EmbeddingJob {
-    pub fn new(row: Row, data_path: &str) -> Result<EmbeddingJob, anyhow::Error> {
+    pub fn new(row: &Row, data_path: &str) -> Result<EmbeddingJob, anyhow::Error> {
         let runtime = Runtime::try_from(row.get::<&str, Option<&str>>("runtime").unwrap_or("ort"))?;
         let runtime_params = if runtime == Runtime::Ort {
             format!(r#"{{ "data_path": "{data_path}" }}"#)

--- a/lantern_cli/src/http_server/mod.rs
+++ b/lantern_cli/src/http_server/mod.rs
@@ -1,9 +1,10 @@
+use crate::types::PoolClient;
 use crate::{logger::LogLevel, types::AnyhowVoidResult};
 use actix_web::{
     error::ErrorInternalServerError, middleware::Logger, web, App, HttpServer, Result,
 };
 use cli::HttpServerArgs;
-use deadpool_postgres::{Config as PoolConfig, Manager, Pool};
+use deadpool_postgres::{Config as PoolConfig, Pool};
 use tokio_postgres::NoTls;
 use utoipa::OpenApi;
 use utoipa_swagger_ui::SwaggerUi;
@@ -14,8 +15,6 @@ mod index;
 mod pq;
 mod search;
 mod setup;
-
-type PoolClient = deadpool::managed::Object<Manager>;
 
 pub const COLLECTION_TABLE_NAME: &str = "_lantern_internal.http_collections";
 

--- a/lantern_cli/src/types.rs
+++ b/lantern_cli/src/types.rs
@@ -1,3 +1,4 @@
 pub type AnyhowUsizeResult = Result<usize, anyhow::Error>;
 pub type AnyhowVoidResult = Result<(), anyhow::Error>;
 pub type ProgressCbFn = Box<dyn Fn(u8) + Send + Sync>;
+pub type PoolClient = deadpool::managed::Object<deadpool_postgres::Manager>;


### PR DESCRIPTION
- Create separate database clients for each worker task. There might be an issue when tokio postgres will cause a deadlock ([reference](https://github.com/sfackler/rust-postgres/issues/840)). Though I could not replicate it locally.
- Generate missed rows after reconnect of client connections