### PR TITLE
Add daemon functions in lantern_extras extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,3 +404,65 @@ lantern-cli pq-table --uri 'postgres://postgres@127.0.0.1:5432/postgres' --table
 In this case this command should be run 10 times for each part of codebook in range [0-9] and `--parallel-task-count` means at most we will run 10 tasks in parallel. This is used to not exceed max connection limit on postgres.
 
 Table should have primary key, in order for this job to work. If primary key is different than `id` provide it using `--pk` argument
+
+## Lantern Daemon in SQL
+Daemon Management
+Enabling the Daemon
+To enable the daemon, set the `lantern_extras.enable_daemon` GUC to true. This can be done by executing the following command:
+
+```sql
+ALTER SYSTEM SET lantern_extras.enable_daemon = true;
+```
+After setting this, you will need to restart the database for the changes to take effect. The daemon will start automatically, targeting the current connected database or databases specified in the `lantern_extras.daemon_databases` GUC.
+
+**Important Notes**
+This is an experimental functionality to enable lantern daemon from SQL
+If the extension is not in shared_preload_libraries, the daemon will start as soon as any of the extension functions are called.
+Starting or stopping the daemon requires a database restart.
+
+
+### SQL Functions for Embedding Jobs
+This functions can be used both with externally managed Lantern Daemon or with a daemon run from the SQL.
+
+**Adding an Embedding Job**
+To add a new embedding job, use the add_embedding_job function:
+
+```sql
+SELECT add_embedding_job(
+    'table_name',        -- Name of the table
+    'src_column',        -- Source column for embeddings
+    'dst_column',        -- Destination column for embeddings
+    'embedding_model',   -- Embedding model to use
+    'runtime',           -- Runtime environment (default: 'ort')
+    'runtime_params',    -- Runtime parameters (default: '{}')
+    'pk',                -- Primary key column (default: 'id')
+    'schema'             -- Schema name (default: 'public')
+);
+```
+
+**Getting Embedding Job Status**
+To get the status of an embedding job, use the get_embedding_job_status function:
+
+```sql
+SELECT * FROM get_embedding_job_status(job_id);
+```
+This will return a table with the following columns:
+
+`status`: The current status of the job.
+`progress`: The progress of the job as a percentage.
+`error`: Any error message if the job failed.
+
+**Canceling an Embedding Job**
+To cancel an embedding job, use the cancel_embedding_job function:
+
+```sql
+SELECT cancel_embedding_job(job_id);
+```
+
+**Resuming an Embedding Job**
+To resume a paused embedding job, use the resume_embedding_job function:
+
+```sql
+SELECT resume_embedding_job(job_id);
+```
+

--- a/README.md
+++ b/README.md
@@ -406,8 +406,6 @@ In this case this command should be run 10 times for each part of codebook in ra
 Table should have primary key, in order for this job to work. If primary key is different than `id` provide it using `--pk` argument
 
 ## Lantern Daemon in SQL
-Daemon Management
-Enabling the Daemon
 To enable the daemon, set the `lantern_extras.enable_daemon` GUC to true. This can be done by executing the following command:
 
 ```sql
@@ -415,7 +413,7 @@ ALTER SYSTEM SET lantern_extras.enable_daemon = true;
 ```
 After setting this, you will need to restart the database for the changes to take effect. The daemon will start automatically, targeting the current connected database or databases specified in the `lantern_extras.daemon_databases` GUC.
 
-**Important Notes**
+**Important Notes**  
 This is an experimental functionality to enable lantern daemon from SQL
 If the extension is not in shared_preload_libraries, the daemon will start as soon as any of the extension functions are called.
 Starting or stopping the daemon requires a database restart.
@@ -424,8 +422,8 @@ Starting or stopping the daemon requires a database restart.
 ### SQL Functions for Embedding Jobs
 This functions can be used both with externally managed Lantern Daemon or with a daemon run from the SQL.
 
-**Adding an Embedding Job**
-To add a new embedding job, use the add_embedding_job function:
+**Adding an Embedding Job**  
+To add a new embedding job, use the `add_embedding_job` function:
 
 ```sql
 SELECT add_embedding_job(
@@ -440,27 +438,27 @@ SELECT add_embedding_job(
 );
 ```
 
-**Getting Embedding Job Status**
-To get the status of an embedding job, use the get_embedding_job_status function:
+**Getting Embedding Job Status**  
+To get the status of an embedding job, use the `get_embedding_job_status` function:
 
 ```sql
 SELECT * FROM get_embedding_job_status(job_id);
 ```
 This will return a table with the following columns:
 
-`status`: The current status of the job.
-`progress`: The progress of the job as a percentage.
-`error`: Any error message if the job failed.
+- `status`: The current status of the job.
+- `progress`: The progress of the job as a percentage.
+- `error`: Any error message if the job failed.
 
-**Canceling an Embedding Job**
-To cancel an embedding job, use the cancel_embedding_job function:
+**Canceling an Embedding Job**  
+To cancel an embedding job, use the `cancel_embedding_job` function:
 
 ```sql
 SELECT cancel_embedding_job(job_id);
 ```
 
-**Resuming an Embedding Job**
-To resume a paused embedding job, use the resume_embedding_job function:
+**Resuming an Embedding Job**  
+To resume a paused embedding job, use the `resume_embedding_job` function:
 
 ```sql
 SELECT resume_embedding_job(job_id);

--- a/lantern_cli/src/logger/mod.rs
+++ b/lantern_cli/src/logger/mod.rs
@@ -20,7 +20,7 @@ impl Logger {
     }
 
     pub fn print_raw(&self, msg: &str) {
-        println!("{}", msg);
+        eprintln!("{}", msg);
     }
 
     pub fn info(&self, msg: &str) {
@@ -28,7 +28,7 @@ impl Logger {
             return;
         }
 
-        println!("[*] [{}] {}", &self.label, msg);
+        eprintln!("[*] [{}] {}", &self.label, msg);
     }
 
     pub fn debug(&self, msg: &str) {
@@ -36,7 +36,7 @@ impl Logger {
             return;
         }
 
-        println!("[+] [{}] {}", &self.label, msg);
+        eprintln!("[+] [{}] {}", &self.label, msg);
     }
 
     pub fn warn(&self, msg: &str) {
@@ -44,7 +44,7 @@ impl Logger {
             return;
         }
 
-        println!("[!] [{}] {}", &self.label, msg);
+        eprintln!("[!] [{}] {}", &self.label, msg);
     }
 
     pub fn error(&self, msg: &str) {

--- a/lantern_cli/src/logger/mod.rs
+++ b/lantern_cli/src/logger/mod.rs
@@ -20,7 +20,7 @@ impl Logger {
     }
 
     pub fn print_raw(&self, msg: &str) {
-        eprintln!("{}", msg);
+        println!("{}", msg);
     }
 
     pub fn info(&self, msg: &str) {
@@ -28,7 +28,7 @@ impl Logger {
             return;
         }
 
-        eprintln!("[*] [{}] {}", &self.label, msg);
+        println!("[*] [{}] {}", &self.label, msg);
     }
 
     pub fn debug(&self, msg: &str) {
@@ -36,7 +36,7 @@ impl Logger {
             return;
         }
 
-        eprintln!("[+] [{}] {}", &self.label, msg);
+        println!("[+] [{}] {}", &self.label, msg);
     }
 
     pub fn warn(&self, msg: &str) {
@@ -44,7 +44,7 @@ impl Logger {
             return;
         }
 
-        eprintln!("[!] [{}] {}", &self.label, msg);
+        println!("[!] [{}] {}", &self.label, msg);
     }
 
     pub fn error(&self, msg: &str) {

--- a/lantern_extras/Cargo.toml
+++ b/lantern_extras/Cargo.toml
@@ -25,10 +25,12 @@ tar = "0.4"
 itertools = "0.11"
 backtrace = "0.3"
 url = "2.2"
-lantern_cli = { path = "../lantern_cli", default-features = false, features=["external-index", "embeddings"] }
+lantern_cli = { path = "../lantern_cli", default-features = false, features=["external-index", "embeddings", "autotune", "daemon"] }
 anyhow = "1.0.75"
 rand = "0.8.5"
 serde_json = "1.0.111"
+tokio-util = "0.7.11"
+tokio = { version = "1.33.0", features = ["rt-multi-thread"] }
 
 [dev-dependencies]
 pgrx-tests = "=0.11.3"

--- a/lantern_extras/Cargo.toml
+++ b/lantern_extras/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lantern_extras"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 
 [lib]

--- a/lantern_extras/src/daemon.rs
+++ b/lantern_extras/src/daemon.rs
@@ -1,0 +1,182 @@
+use std::time::{Duration, Instant};
+
+use lantern_cli::{
+    daemon::{cli::DaemonArgs, start},
+    logger::{LogLevel, Logger},
+    types::AnyhowVoidResult,
+    utils::quote_ident,
+};
+use pgrx::prelude::*;
+use tokio::runtime::Runtime;
+use tokio_util::sync::CancellationToken;
+
+pub fn start_daemon(
+    embeddings: bool,
+    indexing: bool,
+    autotune: bool,
+) -> Result<bool, anyhow::Error> {
+    let cancellation_token = CancellationToken::new();
+    let (db, user, socket_path, port) = Spi::connect(|client| {
+        let row = client
+            .select(
+                "
+           SELECT current_database()::text AS db,
+           (SELECT setting::text FROM pg_settings WHERE name = 'unix_socket_directories') AS socket_path,
+           (SELECT setting::text FROM pg_settings WHERE name = 'port') AS port,
+           (SELECT rolname::text FROM pg_roles WHERE rolsuper = true LIMIT 1) as user
+           ",
+                None,
+                None,
+            )?
+            .first();
+
+        let db = row.get_by_name::<String, &str>("db")?.unwrap();
+        let socket_path = row.get_by_name::<String, &str>("socket_path")?.unwrap();
+        let port = row.get_by_name::<String, &str>("port")?.unwrap();
+        let user = row.get_by_name::<String, &str>("user")?.unwrap();
+
+        Ok::<(String, String, String, String), anyhow::Error>((db, user, socket_path, port))
+    })?;
+
+    let connection_string = format!(
+        "postgresql://{user}@{socket_path}:{port}/{db}",
+        socket_path = socket_path.replace("/", "%2F")
+    );
+
+    std::thread::spawn(move || {
+        let mut last_retry = Instant::now();
+        let mut retry_interval = 5;
+        loop {
+            let logger = Logger::new("Lantern Daemon", LogLevel::Debug);
+            let rt = Runtime::new().unwrap();
+            let res = rt.block_on(start(
+                DaemonArgs {
+                    embeddings,
+                    external_index: indexing,
+                    autotune,
+                    log_level: lantern_cli::daemon::cli::LogLevel::Debug,
+                    databases_table: String::new(),
+                    master_db: None,
+                    master_db_schema: String::new(),
+                    schema: String::from("_lantern_internal"),
+                    target_db: Some(vec![connection_string.clone()]),
+                },
+                Some(logger.clone()),
+                cancellation_token.clone(),
+            ));
+
+            if let Err(e) = res {
+                eprintln!("{e}");
+                logger.error(&format!("{e}"));
+            }
+            if last_retry.elapsed().as_secs() > retry_interval * 2 {
+                // reset retry exponential backoff time if job was not failing constantly
+                retry_interval = 10;
+            }
+            std::thread::sleep(Duration::from_secs(retry_interval));
+            retry_interval *= 2;
+            last_retry = Instant::now();
+        }
+    });
+
+    Ok(true)
+}
+
+#[pg_extern(immutable, parallel_unsafe)]
+fn add_embedding_job<'a>(
+    table: &'a str,
+    src_column: &'a str,
+    dst_column: &'a str,
+    embedding_model: &'a str,
+    runtime: default!(&'a str, "'ort'"),
+    runtime_params: default!(&'a str, "'{}'"),
+    pk: default!(&'a str, "'id'"),
+    schema: default!(&'a str, "'public'"),
+) -> Result<i32, anyhow::Error> {
+    let id: Option<i32> = Spi::get_one_with_args(
+        &format!(
+            r#"
+          ALTER TABLE {table} ADD COLUMN IF NOT EXISTS {dst_column} REAL[];
+          INSERT INTO _lantern_internal.embedding_generation_jobs ("table", "schema", pk, src_column, dst_column, embedding_model, runtime, runtime_params) VALUES
+          ($1, $2, $3, $4, $5, $6, $7, $8::jsonb) RETURNING id;
+        "#,
+            table = quote_ident(table),
+            dst_column = quote_ident(dst_column)
+        ),
+        vec![
+            (PgBuiltInOids::TEXTOID.oid(), table.into_datum()),
+            (PgBuiltInOids::TEXTOID.oid(), schema.into_datum()),
+            (PgBuiltInOids::TEXTOID.oid(), pk.into_datum()),
+            (PgBuiltInOids::TEXTOID.oid(), src_column.into_datum()),
+            (PgBuiltInOids::TEXTOID.oid(), dst_column.into_datum()),
+            (PgBuiltInOids::TEXTOID.oid(), embedding_model.into_datum()),
+            (PgBuiltInOids::TEXTOID.oid(), runtime.into_datum()),
+            (PgBuiltInOids::TEXTOID.oid(), runtime_params.into_datum()),
+        ],
+    )?;
+
+    Ok(id.unwrap())
+}
+
+#[pg_extern(immutable, parallel_safe)]
+fn get_embedding_job_status<'a>(
+    job_id: i32,
+) -> Result<
+    TableIterator<
+        'static,
+        (
+            name!(status, Option<String>),
+            name!(progress, Option<i16>),
+            name!(error, Option<String>),
+        ),
+    >,
+    anyhow::Error,
+> {
+    let tuple = Spi::get_three_with_args(
+        r#"
+          SELECT 
+          CASE 
+            WHEN init_failed_at IS NOT NULL THEN 'failed'
+            WHEN canceled_at IS NOT NULL THEN 'canceled'
+            WHEN init_finished_at IS NOT NULL THEN 'enabled'
+            WHEN init_started_at IS NOT NULL THEN 'in_progress'
+            ELSE 'queued'
+          END AS status,
+          init_progress as progress,
+          init_failure_reason as error
+          FROM _lantern_internal.embedding_generation_jobs
+          WHERE id=$1;
+        "#,
+        vec![(PgBuiltInOids::INT4OID.oid(), job_id.into_datum())],
+    )?;
+
+    Ok(TableIterator::once(tuple))
+}
+
+#[pg_extern(immutable, parallel_safe)]
+fn cancel_embedding_job<'a>(job_id: i32) -> AnyhowVoidResult {
+    Spi::run_with_args(
+        r#"
+          UPDATE _lantern_internal.embedding_generation_jobs
+          SET canceled_at=NOW()
+          WHERE id=$1;
+        "#,
+        Some(vec![(PgBuiltInOids::INT4OID.oid(), job_id.into_datum())]),
+    )?;
+
+    Ok(())
+}
+
+#[pg_extern(immutable, parallel_safe)]
+fn resume_embedding_job<'a>(job_id: i32) -> AnyhowVoidResult {
+    Spi::run_with_args(
+        r#"
+          UPDATE _lantern_internal.embedding_generation_jobs
+          SET canceled_at=NULL
+          WHERE id=$1;
+        "#,
+        Some(vec![(PgBuiltInOids::INT4OID.oid(), job_id.into_datum())]),
+    )?;
+
+    Ok(())
+}

--- a/lantern_extras/src/daemon.rs
+++ b/lantern_extras/src/daemon.rs
@@ -205,8 +205,8 @@ fn resume_embedding_job<'a>(job_id: i32) -> AnyhowVoidResult {
 #[cfg(any(test, feature = "pg_test"))]
 #[pg_schema]
 pub mod tests {
-    use std::time::Duration;
     use crate::*;
+    use std::time::Duration;
 
     #[pg_test]
     fn test_add_daemon_job() {
@@ -251,7 +251,7 @@ pub mod tests {
             // queued
             let rows = client.select("SELECT status, progress, error FROM get_embedding_job_status($1)", None, Some(vec![(PgBuiltInOids::INT4OID.oid(), id.into_datum())]))?;
             let job = rows.first();
-            
+
             let status: &str = job.get(1)?.unwrap();
             let progress: i16 = job.get(2)?.unwrap();
             let error: Option<&str> = job.get(3)?;
@@ -265,7 +265,7 @@ pub mod tests {
             client.update("UPDATE _lantern_internal.embedding_generation_jobs SET init_failed_at=NOW(), init_failure_reason='test';", None, None)?;
             let rows = client.select("SELECT status, progress, error FROM get_embedding_job_status($1)", None, Some(vec![(PgBuiltInOids::INT4OID.oid(), id.into_datum())]))?;
             let job = rows.first();
-            
+
             let status: &str = job.get(1)?.unwrap();
             let progress: i16 = job.get(2)?.unwrap();
             let error: &str = job.get(3)?.unwrap();
@@ -278,7 +278,7 @@ pub mod tests {
             client.update("UPDATE _lantern_internal.embedding_generation_jobs SET init_failed_at=NULL, init_failure_reason=NULL, init_progress=60, init_started_at=NOW();", None, None)?;
             let rows = client.select("SELECT status, progress, error FROM get_embedding_job_status($1)", None, Some(vec![(PgBuiltInOids::INT4OID.oid(), id.into_datum())]))?;
             let job = rows.first();
-            
+
             let status: &str = job.get(1)?.unwrap();
             let progress: i16 = job.get(2)?.unwrap();
             let error: Option<&str> = job.get(3)?;
@@ -286,12 +286,12 @@ pub mod tests {
             assert_eq!(status, "in_progress");
             assert_eq!(progress, 60);
             assert_eq!(error, None);
-            
+
             // Canceled
             client.update("UPDATE _lantern_internal.embedding_generation_jobs SET init_failed_at=NULL, init_failure_reason=NULL, init_progress=0, init_started_at=NULL, canceled_at=NOW();", None, None)?;
             let rows = client.select("SELECT status, progress, error FROM get_embedding_job_status($1)", None, Some(vec![(PgBuiltInOids::INT4OID.oid(), id.into_datum())]))?;
             let job = rows.first();
-            
+
             let status: &str = job.get(1)?.unwrap();
             let progress: i16 = job.get(2)?.unwrap();
             let error: Option<&str> = job.get(3)?;
@@ -299,12 +299,12 @@ pub mod tests {
             assert_eq!(status, "canceled");
             assert_eq!(progress, 0);
             assert_eq!(error, None);
-            
+
             // Enabled
             client.update("UPDATE _lantern_internal.embedding_generation_jobs SET init_failed_at=NULL, init_failure_reason=NULL, init_progress=100, init_started_at=NULL, canceled_at=NULL, init_finished_at=NOW();", None, None)?;
             let rows = client.select("SELECT status, progress, error FROM get_embedding_job_status($1)", None, Some(vec![(PgBuiltInOids::INT4OID.oid(), id.into_datum())]))?;
             let job = rows.first();
-            
+
             let status: &str = job.get(1)?.unwrap();
             let progress: i16 = job.get(2)?.unwrap();
             let error: Option<&str> = job.get(3)?;
@@ -317,7 +317,7 @@ pub mod tests {
         })
         .unwrap();
     }
-    
+
     #[pg_test]
     fn test_cancel_daemon_job() {
         Spi::connect(|mut client| {

--- a/lantern_extras/src/daemon.rs
+++ b/lantern_extras/src/daemon.rs
@@ -222,9 +222,9 @@ pub mod tests {
             )?;
             let id = client.select("SELECT add_embedding_job('t1', 'title', 'title_embedding', 'BAAI/bge-small-en', 'ort', '{}', 'id', 'public')", None, None)?;
 
-            let id: i32 = id.first().get(1)?.unwrap();
+            let id: Option<i32> = id.first().get(1)?;
 
-            assert_eq!(id, 1);
+            assert_eq!(id.is_none(), false);
             Ok::<(), anyhow::Error>(())
         })
         .unwrap();

--- a/lantern_extras/src/daemon.rs
+++ b/lantern_extras/src/daemon.rs
@@ -99,7 +99,7 @@ pub fn start_daemon(
     Ok(true)
 }
 
-#[pg_extern(immutable, parallel_unsafe)]
+#[pg_extern(immutable, parallel_unsafe, security_definer)]
 fn add_embedding_job<'a>(
     table: &'a str,
     src_column: &'a str,
@@ -135,7 +135,7 @@ fn add_embedding_job<'a>(
     Ok(id.unwrap())
 }
 
-#[pg_extern(immutable, parallel_safe)]
+#[pg_extern(immutable, parallel_safe, security_definer)]
 fn get_embedding_job_status<'a>(
     job_id: i32,
 ) -> Result<
@@ -174,7 +174,7 @@ fn get_embedding_job_status<'a>(
     Ok(TableIterator::once(tuple.unwrap()))
 }
 
-#[pg_extern(immutable, parallel_safe)]
+#[pg_extern(immutable, parallel_safe, security_definer)]
 fn cancel_embedding_job<'a>(job_id: i32) -> AnyhowVoidResult {
     Spi::run_with_args(
         r#"
@@ -188,7 +188,7 @@ fn cancel_embedding_job<'a>(job_id: i32) -> AnyhowVoidResult {
     Ok(())
 }
 
-#[pg_extern(immutable, parallel_safe)]
+#[pg_extern(immutable, parallel_safe, security_definer)]
 fn resume_embedding_job<'a>(job_id: i32) -> AnyhowVoidResult {
     Spi::run_with_args(
         r#"

--- a/lantern_extras/src/daemon.rs
+++ b/lantern_extras/src/daemon.rs
@@ -211,9 +211,8 @@ pub mod tests {
     #[pg_test]
     fn test_add_daemon_job() {
         Spi::connect(|mut client| {
-            // reload daemon
-            client.update("DROP EXTENSION lantern_extras; CREATE EXTENSION lantern_extras;", None, None)?;
-            std::thread::sleep(Duration::from_secs(2));
+            // wait for daemon
+            std::thread::sleep(Duration::from_secs(1));
             client.update(
                 "
                 CREATE TABLE t1 (id serial primary key, title text);
@@ -234,9 +233,8 @@ pub mod tests {
     #[pg_test]
     fn test_get_daemon_job() {
         Spi::connect(|mut client| {
-            // reload daemon
-            client.update("DROP EXTENSION lantern_extras; CREATE EXTENSION lantern_extras;", None, None)?;
-            std::thread::sleep(Duration::from_secs(2));
+            // wait for daemon
+            std::thread::sleep(Duration::from_secs(1));
             client.update(
                 "
                 CREATE TABLE t1 (id serial primary key, title text);
@@ -321,9 +319,8 @@ pub mod tests {
     #[pg_test]
     fn test_cancel_daemon_job() {
         Spi::connect(|mut client| {
-            // reload daemon
-            client.update("DROP EXTENSION lantern_extras; CREATE EXTENSION lantern_extras;", None, None)?;
-            std::thread::sleep(Duration::from_secs(2));
+            // wait for daemon
+            std::thread::sleep(Duration::from_secs(1));
             client.update(
                 "
                 CREATE TABLE t1 (id serial primary key, title text);
@@ -352,9 +349,8 @@ pub mod tests {
     #[pg_test]
     fn test_resume_daemon_job() {
         Spi::connect(|mut client| {
-            // reload daemon
-            client.update("DROP EXTENSION lantern_extras; CREATE EXTENSION lantern_extras;", None, None)?;
-            std::thread::sleep(Duration::from_secs(2));
+            // wait for daemon
+            std::thread::sleep(Duration::from_secs(1));
             client.update(
                 "
                 CREATE TABLE t1 (id serial primary key, title text);

--- a/lantern_extras/src/lib.rs
+++ b/lantern_extras/src/lib.rs
@@ -83,6 +83,9 @@ pub unsafe extern "C" fn _PG_init() {
     );
 
     if ENABLE_DAEMON.get() {
+        warning!("Lantern Daemon in SQL is experimental and can lead to undefined behaviour");
+        // TODO:: Make extension working with shared_preload_libs and start daemon only when
+        // started from shared_preload_libs
         daemon::start_daemon(true, false, false).unwrap();
     }
 }

--- a/lantern_extras/src/lib.rs
+++ b/lantern_extras/src/lib.rs
@@ -17,7 +17,12 @@ pub static OPENAI_AZURE_ENTRA_TOKEN: GucSetting<Option<&'static CStr>> =
     GucSetting::<Option<&'static CStr>>::new(None);
 pub static COHERE_TOKEN: GucSetting<Option<&'static CStr>> =
     GucSetting::<Option<&'static CStr>>::new(None);
+
+#[cfg(any(test, feature = "pg_test"))]
 pub static ENABLE_DAEMON: GucSetting<bool> = GucSetting::<bool>::new(true);
+#[cfg(not(any(test, feature = "pg_test")))]
+pub static ENABLE_DAEMON: GucSetting<bool> = GucSetting::<bool>::new(false);
+
 pub static DAEMON_DATABASES: GucSetting<Option<&'static CStr>> =
     GucSetting::<Option<&'static CStr>>::new(None);
 

--- a/lantern_extras/src/lib.rs
+++ b/lantern_extras/src/lib.rs
@@ -17,10 +17,6 @@ pub static OPENAI_AZURE_ENTRA_TOKEN: GucSetting<Option<&'static CStr>> =
     GucSetting::<Option<&'static CStr>>::new(None);
 pub static COHERE_TOKEN: GucSetting<Option<&'static CStr>> =
     GucSetting::<Option<&'static CStr>>::new(None);
-
-#[cfg(any(test, feature = "pg_test"))]
-pub static ENABLE_DAEMON: GucSetting<bool> = GucSetting::<bool>::new(true);
-#[cfg(not(any(test, feature = "pg_test")))]
 pub static ENABLE_DAEMON: GucSetting<bool> = GucSetting::<bool>::new(false);
 
 pub static DAEMON_DATABASES: GucSetting<Option<&'static CStr>> =
@@ -98,7 +94,6 @@ pub mod pg_test {
     }
 
     pub fn postgresql_conf_options() -> Vec<&'static str> {
-        // return any postgresql.conf settings that are required for your tests
-        vec![]
+        vec!["lantern_extras.enable_daemon=true"]
     }
 }

--- a/lantern_extras/src/lib.rs
+++ b/lantern_extras/src/lib.rs
@@ -18,6 +18,8 @@ pub static OPENAI_AZURE_ENTRA_TOKEN: GucSetting<Option<&'static CStr>> =
 pub static COHERE_TOKEN: GucSetting<Option<&'static CStr>> =
     GucSetting::<Option<&'static CStr>>::new(None);
 pub static ENABLE_DAEMON: GucSetting<bool> = GucSetting::<bool>::new(true);
+pub static DAEMON_DATABASES: GucSetting<Option<&'static CStr>> =
+    GucSetting::<Option<&'static CStr>>::new(None);
 
 #[allow(non_snake_case)]
 #[pg_guard]
@@ -60,6 +62,14 @@ pub unsafe extern "C" fn _PG_init() {
         "Used when generating embeddings with Cohere models",
         &COHERE_TOKEN,
         GucContext::Userset,
+        GucFlags::NO_SHOW_ALL,
+    );
+    GucRegistry::define_string_guc(
+        "lantern_extras.daemon_databases",
+        "Databases to watch",
+        "Comma separated list of database names to which daemon will be connected",
+        &DAEMON_DATABASES,
+        GucContext::Sighup,
         GucFlags::NO_SHOW_ALL,
     );
     GucRegistry::define_bool_guc(


### PR DESCRIPTION
Currently it will check `lantern_extras.enable_daemon` GUC on `PgInit` and if it is set to true, it will start the daemon specifying target database as the current connected database or databases from comma separated list of `lantern_extras.daemon_databases` GUC. The issue with this approach is that extension needs to be in `shared_preload_libraries` to automatically call the `PgInit` on postmaster start, if not it will be executed as soon as any of the extension functions are called.

`start_daemon` function will gather connection information (socket path, port, superuser name, db name) create connection string and start the daemon in separate thread in a loop, so if it will exit with error it will try to reconnect with exponential backoff.

Added the following SQL functions:
```sql 
add_embedding_job(
	"table" TEXT,
	"src_column" TEXT,
	"dst_column" TEXT,
	"embedding_model" TEXT,
	"runtime" TEXT DEFAULT 'ort',
	"runtime_params" TEXT DEFAULT '{}',
	"pk" TEXT DEFAULT 'id',
	"schema" TEXT DEFAULT 'public'
) RETURNS INT
```
```sql 
get_embedding_job_status("job_id" INT) RETURNS TABLE ("status" TEXT, "progress" smallint, "error" TEXT)
```
```sql 
get_embedding_job_status("job_id" INT) RETURNS TABLE ("status" TEXT, "progress" smallint, "error" TEXT)
```
```sql 
cancel_embedding_job("job_id" INT) RETURNS VOID
```
```sql 
resume_embedding_job("job_id" INT) RETURNS VOID
```

### ISSUES
- Any of the extension functions should be called after restart, so `PgInit` will be called and daemon will be started
- Start/Stop of daemon now requires restart. You should set `ALTER SYSTEM SET lantern_extras.enable_daemon=true` and restart database

### TODO
- [ ]  Update README
- [ ] Test functions with low-privileged user which don't have access to jobs table 