### PR TITLE
Make embeddings async

### DIFF
--- a/.github/workflows/publish-cli-docker.yaml
+++ b/.github/workflows/publish-cli-docker.yaml
@@ -11,7 +11,7 @@ on:
         type: string
         description: "CLI version"
         required: true
-        default: "0.3.2"
+        default: "0.3.3"
       IMAGE_NAME:
         type: string
         description: "Container image name to tag"

--- a/lantern_cli/Cargo.toml
+++ b/lantern_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lantern_cli"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2021"
 
 [[bin]]

--- a/lantern_cli/Cargo.toml
+++ b/lantern_cli/Cargo.toml
@@ -60,7 +60,7 @@ autotune = []
 pq = ["dep:gcp_auth", "dep:linfa", "dep:linfa-clustering", "dep:md5", "dep:rayon"]
 cli = []
 external-index = []
-embeddings = []
+embeddings = ["dep:bytes"]
 
 [lib]
 doctest = false

--- a/lantern_cli/src/embeddings/core/cohere_runtime.rs
+++ b/lantern_cli/src/embeddings/core/cohere_runtime.rs
@@ -2,7 +2,7 @@ use itertools::Itertools;
 use std::{collections::HashMap, sync::RwLock};
 
 use super::{
-    runtime::{EmbeddingResult, EmbeddingRuntime},
+    runtime::{EmbeddingResult, EmbeddingRuntimeT},
     LoggerFn,
 };
 use crate::HTTPRuntime;
@@ -207,16 +207,16 @@ impl<'a> CohereRuntime<'a> {
     }
 }
 
-impl<'a> EmbeddingRuntime for CohereRuntime<'a> {
-    fn process(
+impl<'a> EmbeddingRuntimeT for CohereRuntime<'a> {
+    async fn process(
         &self,
         model_name: &str,
         inputs: &Vec<&str>,
     ) -> Result<EmbeddingResult, anyhow::Error> {
-        self.post_request("/v1/embed", model_name, inputs)
+        self.post_request("/v1/embed", model_name, inputs).await
     }
 
-    fn get_available_models(&self) -> (String, Vec<(String, bool)>) {
+    async fn get_available_models(&self) -> (String, Vec<(String, bool)>) {
         let map = MODEL_INFO_MAP.read().unwrap();
         let mut res = String::new();
         let mut models = Vec::with_capacity(map.len());

--- a/lantern_cli/src/embeddings/core/openai_runtime.rs
+++ b/lantern_cli/src/embeddings/core/openai_runtime.rs
@@ -3,7 +3,7 @@ use regex::Regex;
 use std::{collections::HashMap, sync::RwLock};
 
 use super::{
-    runtime::{EmbeddingResult, EmbeddingRuntime},
+    runtime::{EmbeddingResult, EmbeddingRuntimeT},
     LoggerFn,
 };
 use crate::HTTPRuntime;
@@ -286,16 +286,16 @@ impl<'a> OpenAiRuntime<'a> {
     }
 }
 
-impl<'a> EmbeddingRuntime for OpenAiRuntime<'a> {
-    fn process(
+impl<'a> EmbeddingRuntimeT for OpenAiRuntime<'a> {
+    async fn process(
         &self,
         model_name: &str,
         inputs: &Vec<&str>,
     ) -> Result<EmbeddingResult, anyhow::Error> {
-        self.post_request("", model_name, inputs)
+        self.post_request("", model_name, inputs).await
     }
 
-    fn get_available_models(&self) -> (String, Vec<(String, bool)>) {
+    async fn get_available_models(&self) -> (String, Vec<(String, bool)>) {
         let map = MODEL_INFO_MAP.read().unwrap();
         let mut res = String::new();
         let mut models = Vec::with_capacity(map.len());

--- a/lantern_cli/src/embeddings/core/ort_runtime.rs
+++ b/lantern_cli/src/embeddings/core/ort_runtime.rs
@@ -520,7 +520,13 @@ impl EncoderService {
                     .map(|v| Value::from_array(session.allocator(), &v).unwrap())
                     .collect();
 
-                let outputs = session.run(inputs).unwrap();
+                let result = session.run(inputs);
+
+                if let Err(e) = result {
+                    anyhow::bail!(e);
+                }
+
+                let outputs = result.unwrap();
 
                 let binding = outputs[0].try_extract()?;
                 let embeddings = binding.view();

--- a/lantern_cli/src/embeddings/core/runtime.rs
+++ b/lantern_cli/src/embeddings/core/runtime.rs
@@ -2,11 +2,14 @@ pub struct EmbeddingResult {
     pub embeddings: Vec<Vec<f32>>,
     pub processed_tokens: usize,
 }
-pub trait EmbeddingRuntime {
+
+pub trait EmbeddingRuntimeT {
     fn process(
         &self,
         model_name: &str,
         inputs: &Vec<&str>,
-    ) -> Result<EmbeddingResult, anyhow::Error>;
-    fn get_available_models(&self) -> (String, Vec<(String, bool)>);
+    ) -> impl std::future::Future<Output = Result<EmbeddingResult, anyhow::Error>> + Send;
+    fn get_available_models(
+        &self,
+    ) -> impl std::future::Future<Output = (String, Vec<(String, bool)>)> + Send;
 }

--- a/lantern_cli/src/embeddings/mod.rs
+++ b/lantern_cli/src/embeddings/mod.rs
@@ -440,7 +440,7 @@ pub fn get_default_batch_size(model: &str) -> usize {
         "thenlper/gte-base" => 1000,
         "thenlper/gte-large" => 800,
         "microsoft/all-MiniLM-L12-v2" => 1000,
-        "naver/splade-v3" => 1000,
+        "naver/splade-v3" => 100,
         "microsoft/all-mpnet-base-v2" => 400,
         "transformers/multi-qa-mpnet-base-dot-v1" => 300,
         "openai/text-embedding-ada-002" => 500,

--- a/lantern_cli/src/http_server/search.rs
+++ b/lantern_cli/src/http_server/search.rs
@@ -44,7 +44,7 @@ pub struct SearchResponse {
         examples (
          ("Search by vector" = (value = json!(r#"{ "column": "vector", "query_vector": [1,0,1], "metric": "cosine", "select": "id,metadata", "k": 10, "ef": 64 }"#) )),
          ("Search with model" = (value = json!(r#"{ "column": "vector", "query_text": "User query text", "query_model": "BAAI/bge-small-en", "metric": "l2sq", "select": "id,metadata", "k": 10, "ef": 64 }"#) ))
-            
+
         ),
     ),
     responses(

--- a/lantern_cli/src/main.rs
+++ b/lantern_cli/src/main.rs
@@ -21,18 +21,26 @@ async fn main() {
         cli::Commands::CreateEmbeddings(args) => {
             let logger = Logger::new("Lantern Embeddings", LogLevel::Debug);
             _main_logger = Some(logger.clone());
-            let res = embeddings::create_embeddings_from_db(args, true, None, None, Some(logger));
-            // Handle error here as this call does not return void as others
-            let logger = _main_logger.as_ref().unwrap();
+            let res = embeddings::create_embeddings_from_db(
+                args,
+                true,
+                None,
+                CancellationToken::new(),
+                Some(logger),
+            )
+            .await;
+
             if let Err(e) = res {
+                let logger = _main_logger.as_ref().unwrap();
                 logger.error(&e.to_string());
+                process::exit(1);
             }
             Ok(())
         }
         cli::Commands::ShowModels(args) => {
             let logger = Logger::new("Lantern Embeddings", LogLevel::Debug);
             _main_logger = Some(logger.clone());
-            embeddings::show_available_models(&args, Some(logger))
+            embeddings::show_available_models(&args, Some(logger)).await
         }
         cli::Commands::ShowRuntimes => {
             let logger = Logger::new("Lantern Embeddings", LogLevel::Debug);
@@ -42,7 +50,7 @@ async fn main() {
         cli::Commands::MeasureModelSpeed(args) => {
             let logger = Logger::new("Lantern Embeddings", LogLevel::Info);
             _main_logger = Some(logger.clone());
-            embeddings::measure_speed::start_speed_test(&args, Some(logger))
+            embeddings::measure_speed::start_speed_test(&args, Some(logger)).await
         }
         cli::Commands::AutotuneIndex(args) => {
             let logger = Logger::new("Lantern Index Autotune", LogLevel::Debug);

--- a/lantern_cli/tests/text_embedding_test.rs
+++ b/lantern_cli/tests/text_embedding_test.rs
@@ -1,4 +1,4 @@
-use lantern_cli::embeddings::core::{get_runtime, Runtime};
+use lantern_cli::embeddings::core::{EmbeddingRuntime, Runtime};
 
 static HELLO_WORLD_TEXT: &'static str = "Hello world!";
 #[rustfmt::skip]
@@ -71,15 +71,15 @@ fn cosine_similarity(v1: &[f32], v2: &[f32]) -> f32 {
 macro_rules! text_embedding_test {
     ($($name:ident: $value:expr,)*) => {
     $(
-        #[test]
-        fn $name() {
-            let runtime = get_runtime(&Runtime::Ort, None, r#"{"data_path": "/tmp/lantern-embeddings-core-test"}"#).unwrap();
+        #[tokio::test]
+        async fn $name() {
+            let runtime = EmbeddingRuntime::new(&Runtime::Ort, None, r#"{"data_path": "/tmp/lantern-embeddings-core-test"}"#).unwrap();
             let (model, input, expected, batch_size, token_count, tolerance) = $value;
             let inputs = itertools::repeat_n(input, batch_size).collect();
             let output = runtime.process(
                 model,
                 &inputs,
-            ).unwrap();
+            ).await.unwrap();
 
             let embeddings = output.embeddings;
             let expected_output: Vec<Vec<f32>> =
@@ -98,9 +98,9 @@ macro_rules! text_embedding_test {
 macro_rules! text_embedding_test_multiple {
     ($($name:ident: $value:expr,)*) => {
     $(
-        #[test]
-        fn $name() {
-            let runtime = get_runtime(&Runtime::Ort, None, r#"{"data_path": "/tmp/lantern-embeddings-core-test"}"#).unwrap();
+        #[tokio::test]
+        async fn $name() {
+            let runtime = EmbeddingRuntime::new(&Runtime::Ort, None, r#"{"data_path": "/tmp/lantern-embeddings-core-test"}"#).unwrap();
             let (model, input1, input2, expected1, expected2, batch_size, token_count, tolerance) = $value;
             let mut inputs = Vec::with_capacity(batch_size);
             let mut expected_output = Vec::with_capacity(batch_size);
@@ -118,7 +118,7 @@ macro_rules! text_embedding_test_multiple {
             let output = runtime.process(
                 model,
                 &inputs,
-            ).unwrap();
+            ).await.unwrap();
 
             let embeddings = output.embeddings;
 


### PR DESCRIPTION
- Add healthcheck for master db connection in daemon, so when the connection will be closed we will know about it and restart the service.
- Changed embedding generation code to async, because we currently need to run ORT executions sequentially, in previous daemon version all the jobs were managed from one table, but now there's a listener for each client database which means that two ORT jobs may be run in parallel. I added locking with Mutex, but as it was not in async runtime the mutex was blocking the threads execution thus blocking all tokio i/o operations. With async runtime we will use Tokio's mutex implementation which is non-blocking for other tasks.