### PR TITLE
Add external indexing tcp server

### DIFF
--- a/.github/workflows/publish-cli-docker.yaml
+++ b/.github/workflows/publish-cli-docker.yaml
@@ -11,7 +11,7 @@ on:
         type: string
         description: "CLI version"
         required: true
-        default: "0.3.17"
+        default: "0.3.19"
       IMAGE_NAME:
         type: string
         description: "Container image name to tag"

--- a/ci/scripts/build.sh
+++ b/ci/scripts/build.sh
@@ -55,7 +55,7 @@ function setup_postgres() {
 }
 
 function setup_lantern() {
-   LANTERN_VERSION=narek/streaming-hnsw-index-selects
+   LANTERN_VERSION=v0.3.1
     git clone --recursive https://github.com/lanterndata/lantern.git /tmp/lantern 
     pushd /tmp/lantern
       git checkout ${LANTERN_VERSION} && \

--- a/lantern_cli/Cargo.toml
+++ b/lantern_cli/Cargo.toml
@@ -51,6 +51,7 @@ utoipa-swagger-ui = { version = "6.0.0", features = ["actix-web"], optional = tr
 actix-web-httpauth = { version = "0.8.1", optional = true }
 tokio-util = "0.7.11"
 byteorder = "1.5.0"
+bitvec = "1.0.1"
 
 [features]
 default = ["cli", "daemon", "http-server", "autotune", "pq", "external-index", "embeddings"]

--- a/lantern_cli/Cargo.toml
+++ b/lantern_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lantern_cli"
-version = "0.3.17"
+version = "0.3.18"
 edition = "2021"
 
 [[bin]]
@@ -50,6 +50,7 @@ utoipa = { version = "4.2.0", optional = true}
 utoipa-swagger-ui = { version = "6.0.0", features = ["actix-web"], optional = true }
 actix-web-httpauth = { version = "0.8.1", optional = true }
 tokio-util = "0.7.11"
+byteorder = "1.5.0"
 
 [features]
 default = ["cli", "daemon", "http-server", "autotune", "pq", "external-index", "embeddings"]

--- a/lantern_cli/Cargo.toml
+++ b/lantern_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lantern_cli"
-version = "0.3.18"
+version = "0.3.19"
 edition = "2021"
 
 [[bin]]

--- a/lantern_cli/src/cli.rs
+++ b/lantern_cli/src/cli.rs
@@ -5,6 +5,7 @@ use super::http_server::cli::HttpServerArgs;
 use super::index_autotune::cli::IndexAutotuneArgs;
 use super::pq::cli::PQArgs;
 use clap::{Parser, Subcommand};
+use lantern_cli::external_index::cli::IndexServerArgs;
 
 #[derive(Subcommand, Debug)]
 pub enum Commands {
@@ -26,6 +27,8 @@ pub enum Commands {
     StartDaemon(DaemonArgs),
     /// Start in http mode
     StartServer(HttpServerArgs),
+    /// Start external index server
+    StartIndexingServer(IndexServerArgs),
 }
 
 #[derive(Parser, Debug)]

--- a/lantern_cli/src/external_index/cli.rs
+++ b/lantern_cli/src/external_index/cli.rs
@@ -188,6 +188,10 @@ pub struct IndexServerArgs {
     #[arg(long, default_value = "0.0.0.0")]
     pub host: String,
 
+    /// Temp directory to save intermediate files
+    #[arg(long, default_value = "/tmp")]
+    pub tmp_dir: String,
+
     /// Port to bind
     #[arg(long, default_value_t = 8998)]
     pub port: usize,

--- a/lantern_cli/src/external_index/cli.rs
+++ b/lantern_cli/src/external_index/cli.rs
@@ -53,6 +53,20 @@ impl UMetricKind {
             _ => anyhow::bail!("Invalid metric {metric_kind}"),
         }
     }
+    pub fn from_u32(metric_kind: u32) -> Result<UMetricKind, anyhow::Error> {
+        match metric_kind {
+            0 => {
+                return Ok(UMetricKind::L2sq);
+            }
+            1 => {
+                return Ok(UMetricKind::Cos);
+            }
+            2 => {
+                return Ok(UMetricKind::Hamming);
+            }
+            _ => anyhow::bail!("Invalid metric {metric_kind}"),
+        }
+    }
     pub fn to_string(&self) -> String {
         match self {
             UMetricKind::L2sq => {
@@ -166,4 +180,15 @@ pub struct CreateIndexArgs {
     /// Index name to use when imporrting index to database
     #[arg(long)]
     pub index_name: Option<String>,
+}
+
+#[derive(Parser, Debug)]
+pub struct IndexServerArgs {
+    /// Host to bind
+    #[arg(long, default_value = "0.0.0.0")]
+    pub host: String,
+
+    /// Port to bind
+    #[arg(long, default_value_t = 8998)]
+    pub port: usize,
 }

--- a/lantern_cli/src/external_index/cli.rs
+++ b/lantern_cli/src/external_index/cli.rs
@@ -55,13 +55,13 @@ impl UMetricKind {
     }
     pub fn from_u32(metric_kind: u32) -> Result<UMetricKind, anyhow::Error> {
         match metric_kind {
-            0 => {
+            3 => {
                 return Ok(UMetricKind::L2sq);
             }
             1 => {
                 return Ok(UMetricKind::Cos);
             }
-            2 => {
+            8 => {
                 return Ok(UMetricKind::Hamming);
             }
             _ => anyhow::bail!("Invalid metric {metric_kind}"),

--- a/lantern_cli/src/external_index/mod.rs
+++ b/lantern_cli/src/external_index/mod.rs
@@ -19,6 +19,7 @@ use postgres_types::FromSql;
 
 pub mod cli;
 mod postgres_large_objects;
+pub mod server;
 pub mod utils;
 
 // Used to control chunk size when copying index file to postgres server

--- a/lantern_cli/src/external_index/server.rs
+++ b/lantern_cli/src/external_index/server.rs
@@ -1,0 +1,401 @@
+use super::cli::{IndexServerArgs, UMetricKind};
+use byteorder::{ByteOrder, LittleEndian};
+use rand::Rng;
+use std::fs;
+use std::io::{Read, Write};
+use std::net::{Shutdown, TcpListener, TcpStream};
+use std::path::Path;
+use std::sync::mpsc::{self, Receiver, SyncSender};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+use usearch::ffi::{IndexOptions, ScalarKind};
+use usearch::Index;
+
+use crate::logger::{LogLevel, Logger};
+use crate::types::*;
+
+const LABEL_SIZE: usize = 8; // for now we are only using 32bit integers
+const INTEGER_SIZE: usize = 4; // for now we are only using 32bit integers
+const PROTOCOL_HEADER_SIZE: usize = 4;
+const INIT_MSG: u32 = 0x13333337;
+const END_MSG: u32 = 0x31333337;
+const ERR_MSG: u32 = 0x37333337;
+// magic byte + pq + metric_kind + quantization + dim + m + efc + ef + num_centroids +
+// num_subvectors + capacity
+static INDEX_HEADER_LENGTH: usize = INTEGER_SIZE * 11;
+type Row = (u64, Vec<f32>);
+
+struct ThreadSafeIndex(Index);
+
+unsafe impl Sync for ThreadSafeIndex {}
+unsafe impl Send for ThreadSafeIndex {}
+fn parse_index_options(
+    logger: Arc<Logger>,
+    stream: Arc<Mutex<TcpStream>>,
+    buf: &[u8],
+) -> Result<IndexOptions, anyhow::Error> {
+    let mut params: [u32; 9] = [0; 9];
+
+    for i in 0..params.len() {
+        let start_idx = INTEGER_SIZE * i;
+        params[i] = u32::from_le_bytes(buf[start_idx..(start_idx + INTEGER_SIZE)].try_into()?);
+    }
+
+    let [pq, metric_kind, quantization, dim, m, ef_construction, ef, num_centroids, num_subvectors] =
+        params;
+
+    let pq = pq == 1;
+
+    logger.info(&format!("Index Params - pq: {pq}, metric_kind: {metric_kind}, quantization: {quantization}, dim: {dim}, m: {m}, ef_construction: {ef_construction}, ef: {ef}, num_subvectors: {num_subvectors}, num_centroids: {num_centroids}"));
+
+    let mut pq_codebook: *const f32 = std::ptr::null();
+
+    if pq {
+        let expected_payload_size = dim as usize * INTEGER_SIZE;
+        let mut buf = vec![0 as u8; expected_payload_size];
+        let mut stream = stream.lock().unwrap();
+        let mut codebook = Vec::with_capacity(num_centroids as usize);
+
+        loop {
+            match read_frame(&mut stream, &mut buf, expected_payload_size)? {
+                ProtocolMessage::Exit => break,
+                ProtocolMessage::Data(buf) => {
+                    let mut vec: Vec<f32> = bytes_to_f32_vec_le(&buf);
+
+                    codebook.append(&mut vec);
+                }
+                _ => anyhow::bail!("Invalid message received"),
+            }
+        }
+
+        logger.info(&format!("Received codebook with {} items", codebook.len()));
+
+        pq_codebook = codebook.as_ptr();
+    }
+
+    Ok(IndexOptions {
+        dimensions: dim as usize,
+        metric: UMetricKind::from_u32(metric_kind)?.value(),
+        quantization: ScalarKind::F32, // TODO:: get from params
+        multi: false,
+        connectivity: m as usize,
+        expansion_add: ef_construction as usize,
+        expansion_search: ef as usize,
+        num_threads: 0, // automatic
+        // note: pq_construction and pq_output distinction is not yet implemented in usearch
+        // in the future, if pq_construction is false, we will use full vectors in memory (and
+        // require large memory for construction) but will output pq-quantized graph
+        //
+        // currently, regardless of pq_construction value, as long as pq_output is true,
+        // we construct a pq_quantized index using quantized values during construction
+        pq_construction: pq,
+        pq_output: pq,
+        num_centroids: num_centroids as usize,
+        num_subvectors: num_subvectors as usize,
+        codebook: pq_codebook,
+    })
+}
+
+fn bytes_to_f32_vec_le(bytes: &[u8]) -> Vec<f32> {
+    let mut float_vec = Vec::with_capacity(bytes.len() / 4);
+
+    for chunk in bytes.chunks_exact(4) {
+        float_vec.push(LittleEndian::read_f32(chunk));
+    }
+
+    float_vec
+}
+
+fn parse_tuple(buf: &[u8]) -> Result<Row, anyhow::Error> {
+    let label = u64::from_le_bytes(buf[..LABEL_SIZE].try_into()?);
+    let vec: Vec<f32> = bytes_to_f32_vec_le(&buf[LABEL_SIZE..]);
+
+    Ok((label, vec))
+}
+
+fn index_chunk(rows: Vec<(u64, Vec<f32>)>, index: Arc<ThreadSafeIndex>) -> AnyhowVoidResult {
+    for row in rows {
+        index.0.add(row.0, &row.1)?;
+    }
+    Ok(())
+}
+
+fn initialize_index(
+    logger: Arc<Logger>,
+    stream: Arc<Mutex<TcpStream>>,
+) -> Result<ThreadSafeIndex, anyhow::Error> {
+    let mut buf = vec![0 as u8; INDEX_HEADER_LENGTH];
+    let mut soc_stream = stream.lock().unwrap();
+    match read_frame(&mut soc_stream, &mut buf, INDEX_HEADER_LENGTH)? {
+        ProtocolMessage::Init(buf) => {
+            drop(soc_stream);
+            let index_options = parse_index_options(
+                logger.clone(),
+                stream.clone(),
+                &buf[PROTOCOL_HEADER_SIZE..INDEX_HEADER_LENGTH - PROTOCOL_HEADER_SIZE],
+            )?;
+            logger.info(&format!(
+                "Creating index with parameters dimensions={} m={} ef={} ef_construction={}",
+                index_options.dimensions,
+                index_options.connectivity,
+                index_options.expansion_search,
+                index_options.expansion_add
+            ));
+
+            let index = Index::new(&index_options)?;
+            let estimated_capacity: u32 = u32::from_le_bytes(
+                buf[INDEX_HEADER_LENGTH - INTEGER_SIZE..INDEX_HEADER_LENGTH]
+                    .try_into()
+                    .unwrap(),
+            );
+            logger.info(&format!("Estimated capcity is {estimated_capacity}"));
+            index.reserve(estimated_capacity as usize)?;
+            let mut soc_stream = stream.lock().unwrap();
+            // send success code
+            soc_stream.write(&[0]).unwrap();
+            Ok(ThreadSafeIndex(index))
+        }
+        _ => anyhow::bail!("send init message first"),
+    }
+}
+
+fn receive_rows(
+    stream: Arc<Mutex<TcpStream>>,
+    logger: Arc<Logger>,
+    index: Arc<ThreadSafeIndex>,
+    worker_tx: SyncSender<Vec<Row>>,
+) -> AnyhowVoidResult {
+    let mut current_capacity = index.0.capacity();
+    let batch_size = 2000;
+    let mut rows_buf = Vec::with_capacity(batch_size);
+    let mut stream = stream.lock().unwrap();
+    let mut received_rows = 0;
+    let expected_payload_size = LABEL_SIZE + INTEGER_SIZE * index.0.dimensions();
+    let mut buf = vec![0 as u8; expected_payload_size];
+
+    loop {
+        match read_frame(&mut stream, &mut buf, expected_payload_size)? {
+            ProtocolMessage::Exit => break,
+            ProtocolMessage::Data(buf) => {
+                let row = parse_tuple(&buf)?;
+
+                received_rows += 1;
+                if received_rows == current_capacity {
+                    current_capacity *= 2;
+                    logger.debug(&format!("Index resized to {current_capacity}"));
+                    index.0.reserve(current_capacity)?;
+                }
+
+                rows_buf.push(row);
+
+                if rows_buf.len() == batch_size {
+                    worker_tx.send(rows_buf.drain(..).collect())?;
+                }
+            }
+            _ => anyhow::bail!("Invalid message received"),
+        }
+    }
+
+    if rows_buf.len() > 0 {
+        worker_tx.send(rows_buf)?;
+    }
+
+    Ok(())
+}
+
+enum ProtocolMessage<'a> {
+    Init(&'a mut Vec<u8>),
+    Data(&'a mut Vec<u8>),
+    Exit,
+}
+
+fn read_frame<'a>(
+    stream: &mut TcpStream,
+    buf: &'a mut Vec<u8>,
+    expected_size: usize,
+) -> Result<ProtocolMessage<'a>, anyhow::Error> {
+    let hdr_size = stream.read(buf)?;
+    if hdr_size < PROTOCOL_HEADER_SIZE {
+        anyhow::bail!("Invalid frame received");
+    }
+
+    match LittleEndian::read_u32(&buf[0..PROTOCOL_HEADER_SIZE]) {
+        END_MSG => Ok(ProtocolMessage::Exit),
+        msg => {
+            if expected_size > hdr_size {
+                // if didn't read the necessarry amount of bytes
+                // wait until the buffer will be filled
+                // we have 1min timeout for socket
+                stream.read_exact(&mut buf[hdr_size..])?;
+            }
+
+            if msg == INIT_MSG {
+                Ok(ProtocolMessage::Init(buf))
+            } else {
+                Ok(ProtocolMessage::Data(buf))
+            }
+        }
+    }
+}
+
+pub fn create_streaming_usearch_index(
+    stream: Arc<Mutex<TcpStream>>,
+    logger: Arc<Logger>,
+) -> Result<(), anyhow::Error> {
+    let start_time = Instant::now();
+    let num_cores: usize = std::thread::available_parallelism().unwrap().into();
+    logger.info(&format!("Number of available CPU cores: {}", num_cores));
+
+    stream
+        .lock()
+        .unwrap()
+        .set_read_timeout(Some(Duration::from_secs(60)))?;
+    let index = Arc::new(initialize_index(logger.clone(), stream.clone())?);
+
+    // Create a vector to store thread handles
+    let mut handles = vec![];
+
+    let (tx, rx): (SyncSender<Vec<Row>>, Receiver<Vec<Row>>) = mpsc::sync_channel(num_cores);
+    let rx_arc = Arc::new(Mutex::new(rx));
+
+    for _ in 0..num_cores {
+        // spawn thread
+        let index_ref = index.clone();
+        let receiver = rx_arc.clone();
+
+        let handle = std::thread::spawn(move || -> AnyhowVoidResult {
+            loop {
+                let lock = receiver.lock();
+
+                if let Err(e) = lock {
+                    anyhow::bail!("{e}");
+                }
+
+                let rx = lock.unwrap();
+                let rows = rx.recv();
+
+                // release the lock so other threads can take rows
+                drop(rx);
+
+                if rows.is_err() {
+                    // channel has been closed
+                    break;
+                }
+
+                index_chunk(rows.unwrap(), index_ref.clone())?;
+            }
+            Ok(())
+        });
+
+        handles.push(handle);
+    }
+
+    receive_rows(stream.clone(), logger.clone(), index.clone(), tx)?;
+
+    // Wait for all threads to finish processing
+    for handle in handles {
+        if let Err(e) = handle.join() {
+            logger.error("{e}");
+            anyhow::bail!("{:?}", e);
+        }
+    }
+
+    logger.debug(&format!(
+        "Indexing took {}s",
+        start_time.elapsed().as_secs()
+    ));
+
+    // Send added row count
+    let mut stream = stream.lock().unwrap();
+    stream.write(&(index.0.size() as u64).to_le_bytes())?;
+
+    // Send index file back
+    logger.info("Start streaming index");
+
+    let mut rng = rand::thread_rng();
+    let index_path = format!("ldb-index-{}.usearch", rng.gen_range(0..1000));
+
+    let streaming_start = Instant::now();
+    index.0.save(&index_path)?;
+    drop(index);
+    logger.debug(&format!(
+        "Writing index to file took {}s{}ms",
+        streaming_start.elapsed().as_secs(),
+        streaming_start.elapsed().subsec_millis()
+    ));
+
+    let streaming_start = Instant::now();
+    let index_file_path = Path::new(&index_path);
+    let mut index_buffer = vec![];
+
+    // TODO:: send index from buffer
+    // index.0.save_to_buffer(index_buffer.as_mut_slice())?;
+
+    let mut reader = fs::File::open(index_file_path)?;
+    reader.read_to_end(&mut index_buffer)?;
+    logger.debug(&format!(
+        "Reading index file took {}s{}ms",
+        streaming_start.elapsed().as_secs(),
+        streaming_start.elapsed().subsec_millis()
+    ));
+
+    // Send index file size
+    stream.write(&(index_buffer.len() as u64).to_le_bytes())?;
+
+    let streaming_start = Instant::now();
+    stream.write_all(&index_buffer)?;
+    logger.debug(&format!(
+        "Sending index file took {}s{}ms",
+        streaming_start.elapsed().as_secs(),
+        streaming_start.elapsed().subsec_millis()
+    ));
+
+    fs::remove_file(index_file_path)?;
+
+    logger.info("Index sent");
+    stream.shutdown(Shutdown::Both).unwrap();
+
+    logger.debug(&format!(
+        "Total indexing took {}s",
+        start_time.elapsed().as_secs()
+    ));
+
+    Ok(())
+}
+
+pub fn start_tcp_server(args: IndexServerArgs, logger: Option<Logger>) -> AnyhowVoidResult {
+    let listener = TcpListener::bind(&format!("{}:{}", args.host, args.port))?;
+    let logger =
+        Arc::new(logger.unwrap_or(Logger::new("Lantern Indexing Server", LogLevel::Debug)));
+
+    logger.info(&format!(
+        "External Indexing Server started on {}:{}",
+        args.host, args.port,
+    ));
+
+    // TODO:: this now accepts only one request at a time
+    // As single indexing job consumes whole CPU
+    for stream in listener.incoming() {
+        match stream {
+            Ok(stream) => {
+                logger.debug(&format!("New connection: {}", stream.peer_addr().unwrap()));
+                let stream = Arc::new(Mutex::new(stream));
+                if let Err(e) = create_streaming_usearch_index(stream.clone(), logger.clone()) {
+                    logger.error(&format!("Indexing error: {e}"));
+                    let mut error_text: Vec<u8> = e.to_string().bytes().collect();
+                    let error_header: [u8; PROTOCOL_HEADER_SIZE] =
+                        unsafe { std::mem::transmute(ERR_MSG.to_le()) };
+                    let mut error_header = error_header.to_vec();
+                    error_header.append(&mut error_text);
+                    let mut stream = stream.lock().unwrap();
+                    let _ = stream.write(error_header.as_slice());
+                    let _ = stream.shutdown(Shutdown::Both);
+                };
+            }
+            Err(e) => {
+                logger.error(&format!("Connection error: {e}"));
+            }
+        }
+    }
+    Ok(())
+}

--- a/lantern_cli/src/external_index/server.rs
+++ b/lantern_cli/src/external_index/server.rs
@@ -75,10 +75,19 @@ fn parse_index_options(
         pq_codebook = codebook.as_ptr();
     }
 
+    let quantization = match quantization {
+        0..=1 => ScalarKind::F32,
+        2 => ScalarKind::F64,
+        3 => ScalarKind::F16,
+        4 => ScalarKind::I8,
+        5 => ScalarKind::B1,
+        _ => anyhow::bail!("Invalid scalar quantization"),
+    };
+
     Ok(IndexOptions {
         dimensions: dim as usize,
         metric: UMetricKind::from_u32(metric_kind)?.value(),
-        quantization: ScalarKind::F32, // TODO:: get from params
+        quantization,
         multi: false,
         connectivity: m as usize,
         expansion_add: ef_construction as usize,

--- a/lantern_cli/src/main.rs
+++ b/lantern_cli/src/main.rs
@@ -83,7 +83,7 @@ async fn main() {
             http_server::start(args, Some(logger))
         }
         cli::Commands::StartIndexingServer(args) => {
-            let logger = Logger::new("Lantern Streaming Index", LogLevel::Debug);
+            let logger = Logger::new("Lantern External Index", LogLevel::Debug);
             _main_logger = Some(logger.clone());
             external_index::server::start_tcp_server(args, Some(logger))
         }

--- a/lantern_cli/src/main.rs
+++ b/lantern_cli/src/main.rs
@@ -82,6 +82,11 @@ async fn main() {
             _main_logger = Some(logger.clone());
             http_server::start(args, Some(logger))
         }
+        cli::Commands::StartIndexingServer(args) => {
+            let logger = Logger::new("Lantern Streaming Index", LogLevel::Debug);
+            _main_logger = Some(logger.clone());
+            external_index::server::start_tcp_server(args, Some(logger))
+        }
     };
 
     let logger = _main_logger.unwrap();

--- a/lantern_cli/tests/external_index_server_test.rs
+++ b/lantern_cli/tests/external_index_server_test.rs
@@ -1,0 +1,320 @@
+use lantern_cli::external_index::cli::UMetricKind;
+use lantern_cli::external_index::server::{END_MSG, ERR_MSG, INIT_MSG, PROTOCOL_HEADER_SIZE};
+use lantern_cli::external_index::{self, cli::IndexServerArgs};
+use std::fs;
+use std::io::prelude::*;
+use std::net::TcpStream;
+use std::os::unix::fs::MetadataExt;
+use std::path::Path;
+use std::str;
+use std::sync::Once;
+use std::time::Duration;
+use usearch::ffi::{IndexOptions, ScalarKind};
+use usearch::Index;
+
+static INIT: Once = Once::new();
+
+pub fn initialize() {
+    INIT.call_once(|| {
+        // download index file for test
+        // download quantized index file for test
+        // download sift dataset
+        // download pq table
+        std::thread::spawn(move || {
+            external_index::server::start_tcp_server(
+                IndexServerArgs {
+                    host: "127.0.0.1".to_owned(),
+                    port: 8998,
+                },
+                None,
+            )
+            .unwrap();
+        });
+        std::thread::sleep(Duration::from_secs(1));
+    });
+}
+
+#[tokio::test]
+async fn test_external_index_server_invalid_header() {
+    initialize();
+    let mut stream = TcpStream::connect("127.0.0.1:8998").unwrap();
+    let bytes_written = stream.write(&[0, 1, 1, 1, 1, 1]).unwrap();
+    assert_eq!(bytes_written, 6);
+    let mut buf: [u8; 64] = [0; 64];
+    stream.read(&mut buf).unwrap();
+
+    assert_eq!(
+        u32::from_le_bytes(buf[..PROTOCOL_HEADER_SIZE].try_into().unwrap()),
+        ERR_MSG
+    );
+
+    let expected_msg = "Invalid message header";
+    assert_eq!(
+        str::from_utf8(
+            buf[PROTOCOL_HEADER_SIZE..PROTOCOL_HEADER_SIZE + expected_msg.len()]
+                .try_into()
+                .unwrap()
+        )
+        .unwrap(),
+        expected_msg
+    );
+}
+
+#[tokio::test]
+async fn test_external_index_server_short_message() {
+    initialize();
+    let mut stream = TcpStream::connect("127.0.0.1:8998").unwrap();
+    let bytes_written = stream.write(&[0, 1]).unwrap();
+    assert_eq!(bytes_written, 2);
+    let mut buf: [u8; 64] = [0; 64];
+    stream.read(&mut buf).unwrap();
+
+    assert_eq!(
+        u32::from_le_bytes(buf[..PROTOCOL_HEADER_SIZE].try_into().unwrap()),
+        ERR_MSG
+    );
+
+    let expected_msg = "Invalid frame received";
+    assert_eq!(
+        str::from_utf8(
+            buf[PROTOCOL_HEADER_SIZE..PROTOCOL_HEADER_SIZE + expected_msg.len()]
+                .try_into()
+                .unwrap()
+        )
+        .unwrap(),
+        expected_msg
+    );
+}
+
+#[tokio::test]
+async fn test_external_index_server_indexing() {
+    initialize();
+    let pq_codebook: *const f32 = std::ptr::null();
+    let index_options = IndexOptions {
+        dimensions: 3,
+        metric: UMetricKind::from_u32(1).unwrap().value(),
+        quantization: ScalarKind::F32,
+        multi: false,
+        connectivity: 12,
+        expansion_add: 64,
+        expansion_search: 32,
+        num_threads: 0, // automatic
+        pq_construction: false,
+        pq_output: false,
+        num_centroids: 0,
+        num_subvectors: 0,
+        codebook: pq_codebook,
+    };
+
+    let tuples = vec![
+        (0, vec![0.0, 0.0, 0.0]),
+        (1, vec![0.0, 0.0, 1.0]),
+        (2, vec![0.0, 0.0, 2.0]),
+        (3, vec![0.0, 0.0, 3.0]),
+        (4, vec![0.0, 1.0, 0.0]),
+        (5, vec![0.0, 1.0, 1.0]),
+        (6, vec![0.0, 1.0, 2.0]),
+        (7, vec![0.0, 1.0, 3.0]),
+        (8, vec![1.0, 0.0, 0.0]),
+        (9, vec![1.0, 0.0, 1.0]),
+        (10, vec![1.0, 0.0, 2.0]),
+        (11, vec![1.0, 0.0, 3.0]),
+        (12, vec![1.0, 1.0, 0.0]),
+        (13, vec![1.0, 1.0, 1.0]),
+    ];
+
+    let mut stream = TcpStream::connect("127.0.0.1:8998").unwrap();
+    let init_msg = [
+        INIT_MSG.to_le_bytes(),
+        (0 as u32).to_le_bytes(),
+        (1 as u32).to_le_bytes(),
+        (32 as u32).to_le_bytes(),
+        (index_options.dimensions as u32).to_le_bytes(),
+        (index_options.connectivity as u32).to_le_bytes(),
+        (index_options.expansion_add as u32).to_le_bytes(),
+        (index_options.expansion_search as u32).to_le_bytes(),
+        (index_options.num_centroids as u32).to_le_bytes(),
+        (index_options.num_subvectors as u32).to_le_bytes(),
+        (tuples.len() as u32).to_le_bytes(),
+    ]
+    .concat();
+
+    let bytes_written = stream.write(&init_msg).unwrap();
+    assert_eq!(bytes_written, init_msg.len());
+    let mut buf: [u8; 1] = [1; 1];
+    stream.read(&mut buf).unwrap();
+
+    assert_eq!(buf[0], 0);
+    let index = Index::new(&index_options).unwrap();
+    index.reserve(tuples.len()).unwrap();
+    for tuple in &tuples {
+        index.add(tuple.0 as u64, &*tuple.1).unwrap();
+        let tuple_buf = unsafe {
+            let byte_count = tuple.1.len() * std::mem::size_of::<f32>();
+
+            // Allocate a buffer for the bytes
+            let mut byte_vec: Vec<u8> = Vec::with_capacity(byte_count);
+            let float_slice = std::slice::from_raw_parts(tuple.1.as_ptr() as *const u8, byte_count);
+            //
+            // // Copy the bytes into the byte vector
+            byte_vec.extend_from_slice(float_slice);
+            let label = (tuple.0 as u64).to_le_bytes();
+            vec![&label, byte_vec.as_slice()].concat()
+        };
+        stream.write_all(&tuple_buf).unwrap();
+    }
+
+    let buf = END_MSG.to_le_bytes();
+    stream.write(&buf).unwrap();
+    let index_file_name = "/tmp/test_external_index_server_indexing.usearch";
+    let index_file_path = Path::new(&index_file_name);
+    index.save(index_file_name).unwrap();
+    let mut reader = fs::File::open(index_file_path).unwrap();
+    let index_size = reader.metadata().unwrap().size();
+    let mut expected_index_buffer = Vec::with_capacity(index_size as usize);
+    reader.read_to_end(&mut expected_index_buffer).unwrap();
+
+    // receiver num tuples added
+    let mut uint64_buf = [0; 8];
+    stream.read_exact(&mut uint64_buf).unwrap();
+    assert_eq!(u64::from_le_bytes(uint64_buf), tuples.len() as u64);
+
+    stream.read_exact(&mut uint64_buf).unwrap();
+    assert_eq!(u64::from_le_bytes(uint64_buf), index_size as u64);
+
+    let mut received_index_buffer = vec![0; index_size as usize];
+    stream.read_exact(&mut received_index_buffer).unwrap();
+
+    let received_index = Index::new(&index_options).unwrap();
+    received_index.reserve(tuples.len()).unwrap();
+    Index::load_from_buffer(&received_index, &received_index_buffer).unwrap();
+
+    assert_eq!(index.size(), received_index.size());
+}
+
+#[tokio::test]
+async fn test_external_index_server_indexing_pq() {
+    initialize();
+    // codebook with num_centroids = 4, num_subvectors = 3
+    let pq_codebook = vec![
+        [0.0, 0.1, 0.0],
+        [0.1, 0.1, 0.1],
+        [0.1, 0.1, 0.2],
+        [0.1, 0.2, 0.1],
+    ];
+    let codebook = pq_codebook.concat().as_ptr();
+    let index_options = IndexOptions {
+        dimensions: 3,
+        metric: UMetricKind::from_u32(1).unwrap().value(),
+        quantization: ScalarKind::F32,
+        multi: false,
+        connectivity: 12,
+        expansion_add: 64,
+        expansion_search: 32,
+        num_threads: 0, // automatic
+        pq_construction: true,
+        pq_output: true,
+        num_centroids: 4,
+        num_subvectors: 3,
+        codebook,
+    };
+
+    let tuples = vec![
+        (0, vec![0.0, 0.0, 0.0]),
+        (1, vec![0.0, 0.0, 1.0]),
+        (2, vec![0.0, 0.0, 2.0]),
+        (3, vec![0.0, 0.0, 3.0]),
+        (4, vec![0.0, 1.0, 0.0]),
+        (5, vec![0.0, 1.0, 1.0]),
+        (6, vec![0.0, 1.0, 2.0]),
+        (7, vec![0.0, 1.0, 3.0]),
+        (8, vec![1.0, 0.0, 0.0]),
+        (9, vec![1.0, 0.0, 1.0]),
+        (10, vec![1.0, 0.0, 2.0]),
+        (11, vec![1.0, 0.0, 3.0]),
+        (12, vec![1.0, 1.0, 0.0]),
+        (13, vec![1.0, 1.0, 1.0]),
+    ];
+
+    let mut stream = TcpStream::connect("127.0.0.1:8998").unwrap();
+    let init_msg = [
+        INIT_MSG.to_le_bytes(),
+        (1 as u32).to_le_bytes(),
+        (1 as u32).to_le_bytes(),
+        (32 as u32).to_le_bytes(),
+        (index_options.dimensions as u32).to_le_bytes(),
+        (index_options.connectivity as u32).to_le_bytes(),
+        (index_options.expansion_add as u32).to_le_bytes(),
+        (index_options.expansion_search as u32).to_le_bytes(),
+        (index_options.num_centroids as u32).to_le_bytes(),
+        (index_options.num_subvectors as u32).to_le_bytes(),
+        (tuples.len() as u32).to_le_bytes(),
+    ]
+    .concat();
+
+    let bytes_written = stream.write(&init_msg).unwrap();
+    assert_eq!(bytes_written, init_msg.len());
+
+    // send codebook
+    for vec in &pq_codebook {
+        let byte_count = vec.len() * std::mem::size_of::<f32>();
+        let mut byte_vec: Vec<u8> = Vec::with_capacity(byte_count);
+        let tuple_buf = unsafe {
+            // Allocate a buffer for the bytes
+            let float_slice = std::slice::from_raw_parts(vec.as_ptr() as *const u8, byte_count);
+
+            // Copy the bytes into the byte vector
+            byte_vec.extend_from_slice(float_slice);
+            byte_vec.as_slice()
+        };
+        stream.write_all(&tuple_buf).unwrap();
+    }
+    let buf = END_MSG.to_le_bytes();
+    stream.write(&buf).unwrap();
+
+    let mut buf: [u8; 1] = [1; 1];
+    stream.read(&mut buf).unwrap();
+
+    assert_eq!(buf[0], 0);
+    let index = Index::new(&index_options).unwrap();
+    index.reserve(tuples.len()).unwrap();
+    for tuple in &tuples {
+        index.add(tuple.0 as u64, &*tuple.1).unwrap();
+        let tuple_buf = unsafe {
+            let byte_count = tuple.1.len() * std::mem::size_of::<f32>();
+
+            // Allocate a buffer for the bytes
+            let mut byte_vec: Vec<u8> = Vec::with_capacity(byte_count);
+            let float_slice = std::slice::from_raw_parts(tuple.1.as_ptr() as *const u8, byte_count);
+            //
+            // // Copy the bytes into the byte vector
+            byte_vec.extend_from_slice(float_slice);
+            let label = (tuple.0 as u64).to_le_bytes();
+            vec![&label, byte_vec.as_slice()].concat()
+        };
+        stream.write_all(&tuple_buf).unwrap();
+    }
+
+    let buf = END_MSG.to_le_bytes();
+    stream.write(&buf).unwrap();
+
+    let index_file_name = "/tmp/test_external_index_server_indexing.usearch";
+    let index_file_path = Path::new(&index_file_name);
+    index.save(index_file_name).unwrap();
+    let mut reader = fs::File::open(index_file_path).unwrap();
+    let index_size = reader.metadata().unwrap().size();
+    let mut expected_index_buffer = Vec::with_capacity(index_size as usize);
+    reader.read_to_end(&mut expected_index_buffer).unwrap();
+
+    // receiver num tuples added
+    let mut uint64_buf = [0; 8];
+    stream.read_exact(&mut uint64_buf).unwrap();
+    assert_eq!(u64::from_le_bytes(uint64_buf), tuples.len() as u64);
+
+    stream.read_exact(&mut uint64_buf).unwrap();
+    assert_eq!(u64::from_le_bytes(uint64_buf), index_size as u64);
+
+    let mut received_index_buffer = vec![0; index_size as usize];
+    stream.read_exact(&mut received_index_buffer).unwrap();
+    assert_eq!(received_index_buffer.len(), expected_index_buffer.len());
+}

--- a/lantern_cli/tests/external_index_server_test.rs
+++ b/lantern_cli/tests/external_index_server_test.rs
@@ -128,7 +128,7 @@ async fn test_external_index_server_indexing() {
         INIT_MSG.to_le_bytes(),
         (0 as u32).to_le_bytes(),
         (1 as u32).to_le_bytes(),
-        (32 as u32).to_le_bytes(),
+        (1 as u32).to_le_bytes(),
         (index_options.dimensions as u32).to_le_bytes(),
         (index_options.connectivity as u32).to_le_bytes(),
         (index_options.expansion_add as u32).to_le_bytes(),
@@ -193,6 +193,111 @@ async fn test_external_index_server_indexing() {
 }
 
 #[tokio::test]
+async fn test_external_index_server_indexing_scalar_quantization() {
+    initialize();
+    let pq_codebook: *const f32 = std::ptr::null();
+    let index_options = IndexOptions {
+        dimensions: 3,
+        metric: UMetricKind::from_u32(1).unwrap().value(),
+        quantization: ScalarKind::F16,
+        multi: false,
+        connectivity: 12,
+        expansion_add: 64,
+        expansion_search: 32,
+        num_threads: 0, // automatic
+        pq_construction: false,
+        pq_output: false,
+        num_centroids: 0,
+        num_subvectors: 0,
+        codebook: pq_codebook,
+    };
+
+    let tuples = vec![
+        (0, vec![0.0, 0.0, 0.0]),
+        (1, vec![0.0, 0.0, 1.0]),
+        (2, vec![0.0, 0.0, 2.0]),
+        (3, vec![0.0, 0.0, 3.0]),
+        (4, vec![0.0, 1.0, 0.0]),
+        (5, vec![0.0, 1.0, 1.0]),
+        (6, vec![0.0, 1.0, 2.0]),
+        (7, vec![0.0, 1.0, 3.0]),
+        (8, vec![1.0, 0.0, 0.0]),
+        (9, vec![1.0, 0.0, 1.0]),
+        (10, vec![1.0, 0.0, 2.0]),
+        (11, vec![1.0, 0.0, 3.0]),
+        (12, vec![1.0, 1.0, 0.0]),
+        (13, vec![1.0, 1.0, 1.0]),
+    ];
+
+    let mut stream = TcpStream::connect("127.0.0.1:8998").unwrap();
+    let init_msg = [
+        INIT_MSG.to_le_bytes(),
+        (0 as u32).to_le_bytes(),
+        (1 as u32).to_le_bytes(),
+        (3 as u32).to_le_bytes(),
+        (index_options.dimensions as u32).to_le_bytes(),
+        (index_options.connectivity as u32).to_le_bytes(),
+        (index_options.expansion_add as u32).to_le_bytes(),
+        (index_options.expansion_search as u32).to_le_bytes(),
+        (index_options.num_centroids as u32).to_le_bytes(),
+        (index_options.num_subvectors as u32).to_le_bytes(),
+        (tuples.len() as u32).to_le_bytes(),
+    ]
+    .concat();
+
+    let bytes_written = stream.write(&init_msg).unwrap();
+    assert_eq!(bytes_written, init_msg.len());
+    let mut buf: [u8; 1] = [1; 1];
+    stream.read(&mut buf).unwrap();
+
+    assert_eq!(buf[0], 0);
+    let index = Index::new(&index_options).unwrap();
+    index.reserve(tuples.len()).unwrap();
+    for tuple in &tuples {
+        index.add(tuple.0 as u64, &*tuple.1).unwrap();
+        let tuple_buf = unsafe {
+            let byte_count = tuple.1.len() * std::mem::size_of::<f32>();
+
+            // Allocate a buffer for the bytes
+            let mut byte_vec: Vec<u8> = Vec::with_capacity(byte_count);
+            let float_slice = std::slice::from_raw_parts(tuple.1.as_ptr() as *const u8, byte_count);
+            //
+            // // Copy the bytes into the byte vector
+            byte_vec.extend_from_slice(float_slice);
+            let label = (tuple.0 as u64).to_le_bytes();
+            vec![&label, byte_vec.as_slice()].concat()
+        };
+        stream.write_all(&tuple_buf).unwrap();
+    }
+
+    let buf = END_MSG.to_le_bytes();
+    stream.write(&buf).unwrap();
+    let index_file_name = "/tmp/test_external_index_server_indexing.usearch";
+    let index_file_path = Path::new(&index_file_name);
+    index.save(index_file_name).unwrap();
+    let mut reader = fs::File::open(index_file_path).unwrap();
+    let index_size = reader.metadata().unwrap().size();
+    let mut expected_index_buffer = Vec::with_capacity(index_size as usize);
+    reader.read_to_end(&mut expected_index_buffer).unwrap();
+
+    // receiver num tuples added
+    let mut uint64_buf = [0; 8];
+    stream.read_exact(&mut uint64_buf).unwrap();
+    assert_eq!(u64::from_le_bytes(uint64_buf), tuples.len() as u64);
+
+    stream.read_exact(&mut uint64_buf).unwrap();
+    assert_eq!(u64::from_le_bytes(uint64_buf), index_size as u64);
+
+    let mut received_index_buffer = vec![0; index_size as usize];
+    stream.read_exact(&mut received_index_buffer).unwrap();
+
+    let received_index = Index::new(&index_options).unwrap();
+    received_index.reserve(tuples.len()).unwrap();
+    Index::load_from_buffer(&received_index, &received_index_buffer).unwrap();
+
+    assert_eq!(index.size(), received_index.size());
+}
+#[tokio::test]
 async fn test_external_index_server_indexing_pq() {
     initialize();
     // codebook with num_centroids = 4, num_subvectors = 3
@@ -241,7 +346,7 @@ async fn test_external_index_server_indexing_pq() {
         INIT_MSG.to_le_bytes(),
         (1 as u32).to_le_bytes(),
         (1 as u32).to_le_bytes(),
-        (32 as u32).to_le_bytes(),
+        (0 as u32).to_le_bytes(),
         (index_options.dimensions as u32).to_le_bytes(),
         (index_options.connectivity as u32).to_le_bytes(),
         (index_options.expansion_add as u32).to_le_bytes(),

--- a/lantern_cli/tests/external_index_server_test.rs
+++ b/lantern_cli/tests/external_index_server_test.rs
@@ -302,6 +302,113 @@ async fn test_external_index_server_indexing_scalar_quantization() {
 }
 
 #[tokio::test]
+async fn test_external_index_server_indexing_hamming_distance() {
+    initialize();
+    let pq_codebook: *const f32 = std::ptr::null();
+    let index_options = IndexOptions {
+        dimensions: 3 * 32,
+        metric: UMetricKind::from_u32(8).unwrap().value(),
+        quantization: ScalarKind::B1,
+        multi: false,
+        connectivity: 12,
+        expansion_add: 64,
+        expansion_search: 32,
+        num_threads: 0, // automatic
+        pq_construction: false,
+        pq_output: false,
+        num_centroids: 0,
+        num_subvectors: 0,
+        codebook: pq_codebook,
+    };
+
+    let tuples = vec![
+        (0, vec![0.0, 0.0, 0.0]),
+        (1, vec![0.0, 0.0, 1.0]),
+        (2, vec![0.0, 0.0, 2.0]),
+        (3, vec![0.0, 0.0, 3.0]),
+        (4, vec![0.0, 1.0, 0.0]),
+        (5, vec![0.0, 1.0, 1.0]),
+        (6, vec![0.0, 1.0, 2.0]),
+        (7, vec![0.0, 1.0, 3.0]),
+        (8, vec![1.0, 0.0, 0.0]),
+        (9, vec![1.0, 0.0, 1.0]),
+        (10, vec![1.0, 0.0, 2.0]),
+        (11, vec![1.0, 0.0, 3.0]),
+        (12, vec![1.0, 1.0, 0.0]),
+        (13, vec![1.0, 1.0, 1.0]),
+    ];
+
+    let mut stream = TcpStream::connect("127.0.0.1:8998").unwrap();
+    let init_msg = [
+        INIT_MSG.to_le_bytes(),
+        (0 as u32).to_le_bytes(),
+        (8 as u32).to_le_bytes(),
+        (5 as u32).to_le_bytes(),
+        (index_options.dimensions as u32).to_le_bytes(),
+        (index_options.connectivity as u32).to_le_bytes(),
+        (index_options.expansion_add as u32).to_le_bytes(),
+        (index_options.expansion_search as u32).to_le_bytes(),
+        (index_options.num_centroids as u32).to_le_bytes(),
+        (index_options.num_subvectors as u32).to_le_bytes(),
+        (tuples.len() as u32).to_le_bytes(),
+    ]
+    .concat();
+
+    let bytes_written = stream.write(&init_msg).unwrap();
+    assert_eq!(bytes_written, init_msg.len());
+    let mut buf: [u8; 1] = [1; 1];
+    stream.read(&mut buf).unwrap();
+
+    assert_eq!(buf[0], 0);
+    let index = Index::new(&index_options).unwrap();
+    index.reserve(tuples.len()).unwrap();
+    for tuple in &tuples {
+        index.add(tuple.0 as u64, &*tuple.1).unwrap();
+        let tuple_buf = unsafe {
+            let byte_count = tuple.1.len() * std::mem::size_of::<f32>();
+
+            // Allocate a buffer for the bytes
+            let mut byte_vec: Vec<u8> = Vec::with_capacity(byte_count);
+            let float_slice = std::slice::from_raw_parts(tuple.1.as_ptr() as *const u8, byte_count);
+            //
+            // // Copy the bytes into the byte vector
+            byte_vec.extend_from_slice(float_slice);
+            let label = (tuple.0 as u64).to_le_bytes();
+            vec![&label, byte_vec.as_slice()].concat()
+        };
+        stream.write_all(&tuple_buf).unwrap();
+    }
+
+    let buf = END_MSG.to_le_bytes();
+    stream.write(&buf).unwrap();
+    let index_file_name = "/tmp/test_external_index_server_indexing.usearch";
+    let index_file_path = Path::new(&index_file_name);
+    index.save(index_file_name).unwrap();
+    let mut reader = fs::File::open(index_file_path).unwrap();
+    let index_size = reader.metadata().unwrap().size();
+    let mut expected_index_buffer = Vec::with_capacity(index_size as usize);
+    reader.read_to_end(&mut expected_index_buffer).unwrap();
+
+    // receiver num tuples added
+    let mut uint64_buf = [0; 8];
+    stream.read_exact(&mut uint64_buf).unwrap();
+    assert_eq!(u64::from_le_bytes(uint64_buf), tuples.len() as u64);
+
+    stream.read_exact(&mut uint64_buf).unwrap();
+    let received_index_size = u64::from_le_bytes(uint64_buf);
+    assert!(received_index_size > 0);
+
+    let mut received_index_buffer = vec![0; received_index_size as usize];
+    stream.read_exact(&mut received_index_buffer).unwrap();
+
+    let received_index = Index::new(&index_options).unwrap();
+    received_index.reserve(tuples.len()).unwrap();
+    Index::load_from_buffer(&received_index, &received_index_buffer).unwrap();
+
+    assert_eq!(index.size(), received_index.size());
+}
+
+#[tokio::test]
 async fn test_external_index_server_indexing_pq() {
     initialize();
     // codebook with num_centroids = 4, num_subvectors = 3


### PR DESCRIPTION
Add external indexing tcp server, which will accept streamed tuples from C, create usearch index and send index back via socket

## TODO

- [x] Handle scalar quantization
- [x] Add tests
- [x] Decide on allowing more than 1 connection at a time