### PR TITLE
External Indexing Server Status

### DIFF
--- a/.github/workflows/publish-cli-docker.yaml
+++ b/.github/workflows/publish-cli-docker.yaml
@@ -11,7 +11,7 @@ on:
         type: string
         description: "CLI version"
         required: true
-        default: "0.3.21"
+        default: "0.3.22"
       IMAGE_NAME:
         type: string
         description: "Container image name to tag"

--- a/lantern_cli/Cargo.toml
+++ b/lantern_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lantern_cli"
-version = "0.3.21"
+version = "0.3.22"
 edition = "2021"
 
 [[bin]]

--- a/lantern_cli/src/external_index/cli.rs
+++ b/lantern_cli/src/external_index/cli.rs
@@ -182,7 +182,7 @@ pub struct CreateIndexArgs {
     pub index_name: Option<String>,
 }
 
-#[derive(Parser, Debug)]
+#[derive(Parser, Debug, Clone)]
 pub struct IndexServerArgs {
     /// Host to bind
     #[arg(long, default_value = "0.0.0.0")]
@@ -195,6 +195,10 @@ pub struct IndexServerArgs {
     /// Port to bind
     #[arg(long, default_value_t = 8998)]
     pub port: usize,
+
+    /// Status Server Port to bind
+    #[arg(long, default_value_t = 8999)]
+    pub status_port: usize,
 
     /// SSL Certificate path
     #[arg(long)]

--- a/lantern_cli/src/external_index/server.rs
+++ b/lantern_cli/src/external_index/server.rs
@@ -621,10 +621,11 @@ fn start_status_server(
                 );
                 let response_bytes = status_json.as_bytes();
                 let response_len = response_bytes.len();
-                stream.write("HTTP/1.1 200\n".as_bytes())?;
-                stream.write("Content-Type: application/json\n".as_bytes())?;
-                stream.write(format!("Content-Length: {response_len}\n\n").as_bytes())?;
-                stream.write(status_json.as_bytes())?;
+                stream.write("HTTP/1.1 200\r\n".as_bytes())?;
+                stream.write("Content-Type: application/json\r\n".as_bytes())?;
+                stream.write(format!("Content-Length: {response_len}\r\n\r\n").as_bytes())?;
+                stream.write(response_bytes)?;
+                stream.write(&[0x0D, 0x0A])?;
             }
             Err(e) => {
                 logger.error(&format!("Connection error: {e}"));

--- a/lantern_cli/src/external_index/server.rs
+++ b/lantern_cli/src/external_index/server.rs
@@ -583,6 +583,8 @@ fn start_indexing_server(
                     let error_header: [u8; PROTOCOL_HEADER_SIZE] =
                         unsafe { std::mem::transmute(ERR_MSG.to_le()) };
                     let mut error_header = error_header.to_vec();
+                    let mut error_msg_len = (error_text.len() as u32).to_le_bytes().to_vec();
+                    error_header.append(&mut error_msg_len);
                     error_header.append(&mut error_text);
                     let mut stream = connection_stream.lock().unwrap();
                     let _ = stream.write_data(error_header.as_slice());

--- a/lantern_cli/tests/external_index_server_test.rs
+++ b/lantern_cli/tests/external_index_server_test.rs
@@ -1,6 +1,8 @@
 use isahc::{ReadResponseExt, Request};
 use lantern_cli::external_index::cli::UMetricKind;
-use lantern_cli::external_index::server::{END_MSG, ERR_MSG, INIT_MSG, PROTOCOL_HEADER_SIZE};
+use lantern_cli::external_index::server::{
+    END_MSG, ERR_MSG, INIT_MSG, PROTOCOL_HEADER_SIZE, PROTOCOL_VERSION,
+};
 use lantern_cli::external_index::{self, cli::IndexServerArgs};
 use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
 use rustls::pki_types::{CertificateDer, UnixTime};
@@ -142,6 +144,8 @@ async fn test_external_index_server_invalid_header() {
     let mut stream = TcpStream::connect("127.0.0.1:8998").unwrap();
     let mut uint32_buf = [0; 4];
     stream.read_exact(&mut uint32_buf).unwrap();
+    assert_eq!(u32::from_le_bytes(uint32_buf), PROTOCOL_VERSION);
+    stream.read_exact(&mut uint32_buf).unwrap();
     assert_eq!(u32::from_le_bytes(uint32_buf), 0x1);
     let bytes_written = stream.write(&[0, 1, 1, 1, 1, 1]).unwrap();
     assert_eq!(bytes_written, 6);
@@ -167,6 +171,8 @@ async fn test_external_index_server_short_message() {
     initialize();
     let mut stream = TcpStream::connect("127.0.0.1:8998").unwrap();
     let mut uint32_buf = [0; 4];
+    stream.read_exact(&mut uint32_buf).unwrap();
+    assert_eq!(u32::from_le_bytes(uint32_buf), PROTOCOL_VERSION);
     stream.read_exact(&mut uint32_buf).unwrap();
     assert_eq!(u32::from_le_bytes(uint32_buf), 0x1);
     let bytes_written = stream.write(&[0, 1]).unwrap();
@@ -227,6 +233,8 @@ async fn test_external_index_server_indexing() {
 
     let mut stream = TcpStream::connect("127.0.0.1:8998").unwrap();
     let mut uint32_buf = [0; 4];
+    stream.read_exact(&mut uint32_buf).unwrap();
+    assert_eq!(u32::from_le_bytes(uint32_buf), PROTOCOL_VERSION);
     stream.read_exact(&mut uint32_buf).unwrap();
     assert_eq!(u32::from_le_bytes(uint32_buf), 0x1);
 
@@ -374,6 +382,8 @@ async fn test_external_index_server_indexing_ssl() {
     let mut stream = rustls::Stream::new(&mut conn, &mut sock);
     let mut uint32_buf = [0; 4];
     stream.read_exact(&mut uint32_buf).unwrap();
+    assert_eq!(u32::from_le_bytes(uint32_buf), PROTOCOL_VERSION);
+    stream.read_exact(&mut uint32_buf).unwrap();
     assert_eq!(u32::from_le_bytes(uint32_buf), 0x1);
 
     let init_msg = [
@@ -485,6 +495,8 @@ async fn test_external_index_server_indexing_scalar_quantization() {
     let mut stream = TcpStream::connect("127.0.0.1:8998").unwrap();
     let mut uint32_buf = [0; 4];
     stream.read_exact(&mut uint32_buf).unwrap();
+    assert_eq!(u32::from_le_bytes(uint32_buf), PROTOCOL_VERSION);
+    stream.read_exact(&mut uint32_buf).unwrap();
     assert_eq!(u32::from_le_bytes(uint32_buf), 0x1);
     let init_msg = [
         INIT_MSG.to_le_bytes(),
@@ -594,6 +606,8 @@ async fn test_external_index_server_indexing_hamming_distance() {
 
     let mut stream = TcpStream::connect("127.0.0.1:8998").unwrap();
     let mut uint32_buf = [0; 4];
+    stream.read_exact(&mut uint32_buf).unwrap();
+    assert_eq!(u32::from_le_bytes(uint32_buf), PROTOCOL_VERSION);
     stream.read_exact(&mut uint32_buf).unwrap();
     assert_eq!(u32::from_le_bytes(uint32_buf), 0x1);
     let init_msg = [
@@ -711,6 +725,8 @@ async fn test_external_index_server_indexing_pq() {
 
     let mut stream = TcpStream::connect("127.0.0.1:8998").unwrap();
     let mut uint32_buf = [0; 4];
+    stream.read_exact(&mut uint32_buf).unwrap();
+    assert_eq!(u32::from_le_bytes(uint32_buf), PROTOCOL_VERSION);
     stream.read_exact(&mut uint32_buf).unwrap();
     assert_eq!(u32::from_le_bytes(uint32_buf), 0x1);
     let init_msg = [


### PR DESCRIPTION
- Add status server for external indexing
- Send server type (router or indexer) before starting indexing